### PR TITLE
Require explicit request authorization in non-development environments

### DIFF
--- a/lib/app_profiler.rb
+++ b/lib/app_profiler.rb
@@ -27,6 +27,7 @@ module AppProfiler
   mattr_accessor :logger
   mattr_accessor :root
   mattr_accessor :profile_root
+  mattr_accessor :request_authorization_required
 
   mattr_accessor :speedscope_host, default: "https://speedscope.app"
   mattr_accessor :autoredirect, default: false
@@ -56,6 +57,18 @@ module AppProfiler
 
     def profile_data_header
       @@profile_data_header ||= profile_header.dup << "-Data" # rubocop:disable Style/ClassVars
+    end
+
+    def authorize_request
+      Thread.current[:app_profiler_authorized] = true
+    end
+
+    def deauthorize_request
+      Thread.current[:app_profiler_authorized] = nil
+    end
+
+    def request_authorized?
+      Thread.current[:app_profiler_authorized]
     end
   end
 end

--- a/lib/app_profiler/middleware.rb
+++ b/lib/app_profiler/middleware.rb
@@ -15,6 +15,8 @@ module AppProfiler
     end
 
     def call(env)
+      AppProfiler.deauthorize_request if AppProfiler.request_authorization_required
+
       profile(env) do
         @app.call(env)
       end

--- a/lib/app_profiler/profiler.rb
+++ b/lib/app_profiler/profiler.rb
@@ -25,6 +25,8 @@ module AppProfiler
       end
 
       def results
+        return if AppProfiler.request_authorization_required && !AppProfiler.request_authorized?
+
         stackprof_profile = stackprof_results
 
         return unless stackprof_profile

--- a/lib/app_profiler/railtie.rb
+++ b/lib/app_profiler/railtie.rb
@@ -25,6 +25,7 @@ module AppProfiler
         "tmp", "app_profiler"
       )
       AppProfiler.context = app.config.app_profiler.context || Rails.env
+      AppProfiler.request_authorization_required = !(Rails.env.development? || Rails.env.test?)
     end
 
     initializer "app_profiler.add_middleware" do |app|

--- a/test/app_profiler/profiler_test.rb
+++ b/test/app_profiler/profiler_test.rb
@@ -121,5 +121,33 @@ module AppProfiler
 
       assert_nil(Profiler.results)
     end
+
+    test "profile does not return results if an authorization is required and not given" do
+      with_authorization_required do
+        AppProfiler.logger.expects(:info).never
+        assert_equal(true, Profiler.send(:start, stackprof_profile))
+        assert_equal(true, Profiler.send(:running?))
+        assert_nil(Profiler.results)
+        assert_equal(true, Profiler.send(:stop))
+        assert_nil(Profiler.results)
+      end
+    end
+
+    test "profile runs correctly, if an authorization is required and is given" do
+      with_authorization_required do
+        AppProfiler.logger.expects(:info).never
+
+        assert_equal(true, Profiler.send(:start, stackprof_profile))
+        AppProfiler.send(:authorize_request)
+
+        assert_equal(true, Profiler.send(:running?))
+        assert_equal(true, Profiler.send(:stop))
+        assert_equal(false, Profiler.send(:running?))
+
+        profile = Profiler.results
+        assert_instance_of(AppProfiler::Profile, profile)
+        assert_predicate(profile, :valid?)
+      end
+    end
   end
 end

--- a/test/support/test_helper.rb
+++ b/test/support/test_helper.rb
@@ -39,6 +39,14 @@ module AppProfiler
       AppProfiler.context = old_context
     end
 
+    def with_authorization_required
+      AppProfiler.request_authorization_required = true
+      yield
+    ensure
+      AppProfiler.send(:deauthorize_request)
+      AppProfiler.request_authorization_required = false
+    end
+
     private
 
     def tmp_profiles


### PR DESCRIPTION
This would be a nice to have for production and staging environments.

I took the same approach that rack-mini-profiler does.

An example of authorizing a request for profiling (in Rails):

```ruby
class ApplicationController < ActionController::Base
  before_action do
    if admin_user_signed_in?
      AppProfiler.authorize_request
    end
  end
end
```