### PR TITLE
Change object profiling defaults

### DIFF
--- a/lib/app_profiler/request_parameters.rb
+++ b/lib/app_profiler/request_parameters.rb
@@ -4,8 +4,8 @@ require "rack"
 
 module AppProfiler
   class RequestParameters
-    DEFAULT_INTERVALS = { "cpu" => 1000, "wall" => 1000, "object" => 10000 }.freeze
-    MIN_INTERVALS = { "cpu" => 200, "wall" => 200, "object" => 10000 }.freeze
+    DEFAULT_INTERVALS = { "cpu" => 1000, "wall" => 1000, "object" => 2000 }.freeze
+    MIN_INTERVALS = { "cpu" => 200, "wall" => 200, "object" => 400 }.freeze
     MODES = DEFAULT_INTERVALS.keys.freeze
 
     def initialize(request)

--- a/lib/app_profiler/version.rb
+++ b/lib/app_profiler/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module AppProfiler
-  VERSION = "0.0.1"
+  VERSION = "0.0.2"
 end


### PR DESCRIPTION
The current object profiling defaults are to take a sample every 10,000 objects and not be able to set that lower. The few times I've used it, I've gotten lots of profiles which have one or two samples in them. The p50 of a page cache hit on Shopify in terms of object allocation is in the 10-20k range for most endpoints.

This PR changes the default object sampling rate to 2000 for object profiling. This is still conservatively low and should generate a good number of samples for non-cache hits where many more objects get generated. It also lowers the acceptable minimum interval to 400. This also feels fairly conservative as a low end, though it will gather a lot of samples for very expensive requests. But at that level, it should give 30-50 samples for a page cache hit, which is very close to what CPU profiles do now. And it should actually be useful to hunt down object allocation hogs.