### PR TITLE
Explicitly allow push to rubygems

### DIFF
--- a/app_profiler.gemspec
+++ b/app_profiler.gemspec
@@ -23,6 +23,8 @@ Gem::Specification.new do |spec|
   spec.files = Dir["lib/**/*.rb"]
   spec.require_paths = %w(lib)
 
+  spec.metadata['allowed_push_host'] = "https://rubygems.org"
+
   spec.add_dependency("activesupport", ">= 5.2")
   spec.add_dependency("railties", ">= 5.2")
   spec.add_dependency("rack")

--- a/app_profiler.gemspec
+++ b/app_profiler.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.files = Dir["lib/**/*.rb"]
   spec.require_paths = %w(lib)
 
-  spec.metadata['allowed_push_host'] = "https://rubygems.org"
+  spec.metadata["allowed_push_host"] = "https://rubygems.org"
 
   spec.add_dependency("activesupport", ">= 5.2")
   spec.add_dependency("railties", ">= 5.2")


### PR DESCRIPTION
https://github.com/Shopify/shipit-engine/pull/1037 changed Shipit to required an explicit destination for gem releases. The last deploy built correctly but failed to release the gem because of this check.

This updates the gemspec so shipit will allow the gem to be pushed to rubygems.