### PR TITLE
Bump to 0.0.3 to avoid old/yanked gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    app_profiler (0.0.2)
+    app_profiler (0.0.3)
       activesupport (>= 5.2)
       rack
       railties (>= 5.2)

--- a/lib/app_profiler/version.rb
+++ b/lib/app_profiler/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module AppProfiler
-  VERSION = "0.0.2"
+  VERSION = "0.0.3"
 end


### PR DESCRIPTION
So close :-)

```
Pushing gem to https://rubygems.org...
A yanked version already exists (app_profiler-0.0.2).
Repushing of gem versions is not allowed. Please use a new version and retry
```

Sure enough:

<img width="310" alt="Screen Shot 2020-05-20 at 1 18 30 PM" src="https://user-images.githubusercontent.com/7451862/82476666-6a774b00-9a9c-11ea-8830-9faec188600f.png">

So I guess there once was a gem named `app_profiler` that published a single version in 2009. Fair enough -- up to `0.0.3` we go!