### PR TITLE
Document before_profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,17 @@ class AppProfilerAuthorizedMiddleware < AppProfiler::Middleware
 end
 ```
 
+You can also restrict running profiling at all by using `before_profile`. For
+example you may wish to prevent anonymous users triggering the profiler:
+
+```ruby
+class AppProfilerAuthorizedMiddleware < AppProfiler::Middleware
+  def before_profile(env, params)
+    current_user.present?
+  end
+end
+```
+
 The custom middleware can then be configured like the following:
 
 ```ruby


### PR DESCRIPTION
[`before_profile`](https://github.com/Shopify/app_profiler/blob/38aad4eb8445f07d839d257bd469fb62d7bc2033/lib/app_profiler/middleware.rb#L50) is currently not mentioned in the README.