### PR TITLE
Add --ignore-workspace-root-check flag to yarn add

### DIFF
--- a/lib/app_profiler/viewer/speedscope_viewer.rb
+++ b/lib/app_profiler/viewer/speedscope_viewer.rb
@@ -33,7 +33,10 @@ module AppProfiler
       def setup_yarn
         ensure_yarn_installed
         yarn("init --yes") unless package_json_exists?
-        yarn("add --dev speedscope")
+        # We currently only support this gem in the root Gemfile.
+        # See https://github.com/Shopify/app_profiler/issues/15
+        # for more information
+        yarn("add --dev --ignore-workspace-root-check speedscope")
       end
 
       def ensure_yarn_installed

--- a/test/app_profiler/viewer/speedscope_viewer_test.rb
+++ b/test/app_profiler/viewer/speedscope_viewer_test.rb
@@ -18,7 +18,7 @@ module AppProfiler
         viewer = SpeedscopeViewer.new(profile)
         viewer.expects(:system).with("which yarn > /dev/null").returns(true)
         viewer.expects(:system).with("yarn init --yes").returns(true)
-        viewer.expects(:system).with("yarn add --dev speedscope").returns(true)
+        viewer.expects(:system).with("yarn add --dev --ignore-workspace-root-check speedscope").returns(true)
         viewer.expects(:system).with("yarn run speedscope \"#{profile.file}\"").returns(true)
 
         viewer.view


### PR DESCRIPTION
Closes #15 

When running a local profile, `yarn add` fails with the following message: 

```
yarn add v1.13.0
error Running this command will add the dependency to the workspace root rather than the workspace itself, which might not be what you want - if you really meant it, make it explicit by running this command again with the -W flag (or --ignore-workspace-root-check).
info Visit https://yarnpkg.com/en/docs/cli/add for documentation about this command.
2020-07-06 18:34:36 -0400: Rack app error handling request { GET / }
#<AppProfiler::Viewer::SpeedscopeViewer::YarnError: Failed to run add --dev speedscope.>
```

(rest of stacktrace in issue)

Adding this seems to fix it, but not sure if I'm missing something as I don't really know much about yarn.