### PR TITLE
Generate predictable GCS url

### DIFF
--- a/lib/app_profiler/profile.rb
+++ b/lib/app_profiler/profile.rb
@@ -63,14 +63,7 @@ module AppProfiler
     private
 
     def path
-      filename = [
-        Time.zone.now.strftime("%Y%m%d-%H%M%S"),
-        mode,
-        id,
-        Socket.gethostname,
-      ].compact.join("-") << ".json"
-
-      AppProfiler.profile_root.join(filename)
+      AppProfiler.profile_root.join("#{id}.json")
     end
   end
 end


### PR DESCRIPTION
I often get requests from people (recent one was just now) asking me to "find" their trace in the GCS bucket. If the request times out, if profiler headers are not present in the response, so they cannot find it. It also came up during an incident.

Once this gets shipped, we should update the development guide to let people know how to find their "lost" profile.
