### PR TITLE
Make start and stop public

### DIFF
--- a/lib/app_profiler.rb
+++ b/lib/app_profiler.rb
@@ -43,6 +43,15 @@ module AppProfiler
       Profiler.run(*args, &block)
     end
 
+    def start(*args)
+      Profiler.start(*args)
+    end
+
+    def stop
+      Profiler.stop
+      Profiler.results
+    end
+
     def profile_header=(profile_header)
       @@profile_header = profile_header # rubocop:disable Style/ClassVars
       @@request_profile_header = nil    # rubocop:disable Style/ClassVars

--- a/lib/app_profiler/profiler.rb
+++ b/lib/app_profiler/profiler.rb
@@ -24,21 +24,6 @@ module AppProfiler
         stop if started
       end
 
-      def results
-        stackprof_profile = stackprof_results
-
-        return unless stackprof_profile
-
-        Profile.from_stackprof(stackprof_profile)
-      rescue => error
-        AppProfiler.logger.info(
-          "[Profiler] failed to obtain the profile error_class=#{error.class} error_message=#{error.message}"
-        )
-        nil
-      end
-
-      private
-
       def start(params = {})
         # Do not start the profiler if StackProf was started somewhere else.
         return false if running?
@@ -58,6 +43,21 @@ module AppProfiler
       def stop
         StackProf.stop
       end
+
+      def results
+        stackprof_profile = stackprof_results
+
+        return unless stackprof_profile
+
+        Profile.from_stackprof(stackprof_profile)
+      rescue => error
+        AppProfiler.logger.info(
+          "[Profiler] failed to obtain the profile error_class=#{error.class} error_message=#{error.message}"
+        )
+        nil
+      end
+
+      private
 
       def stackprof_results
         StackProf.results

--- a/test/app_profiler/run_test.rb
+++ b/test/app_profiler/run_test.rb
@@ -5,11 +5,25 @@ require "test_helper"
 module AppProfiler
   class RunTest < TestCase
     test ".run delegates to Profiler.run" do
-      profile = AppProfiler.run(stackprof_profile(mode: :cpu, interval: 2000)) do
-        sleep(0.1)
-      end
+      Profiler.expects(:run)
 
-      assert_instance_of(AppProfiler::Profile, profile)
+      AppProfiler.run do
+        sleep 0.1
+      end
+    end
+
+    test ".start delegates to Profiler.start" do
+      Profiler.expects(:start)
+
+      AppProfiler.start
+    end
+
+    test ".stop stops profiler and gets results" do
+      AppProfiler.start
+      sleep 0.1
+      profile = AppProfiler.stop
+
+      assert_instance_of(Profile, profile)
     end
   end
 end


### PR DESCRIPTION
Exposes `AppProfiler.start` and `AppProfiler.stop` as an alternative way of profiling non-block friendly code.