### PR TITLE
Stop unnecessary yarn adds

### DIFF
--- a/lib/app_profiler/viewer/speedscope_viewer.rb
+++ b/lib/app_profiler/viewer/speedscope_viewer.rb
@@ -37,7 +37,7 @@ module AppProfiler
         # We currently only support this gem in the root Gemfile.
         # See https://github.com/Shopify/app_profiler/issues/15
         # for more information
-        yarn("add --dev --ignore-workspace-root-check speedscope")
+        yarn("add --dev --ignore-workspace-root-check speedscope") unless speedscope_added?
       end
 
       def ensure_yarn_installed
@@ -55,6 +55,10 @@ module AppProfiler
 
       def package_json_exists?
         AppProfiler.root.join("package.json").exist?
+      end
+
+      def speedscope_added?
+        AppProfiler.root.join("node_modules/speedscope").exist?
       end
 
       def exec(command)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -20,7 +20,8 @@ Pathname.new(__dir__).join("support").glob("**/*.rb").each do |file|
 end
 
 TEST_ROOT = Pathname.new(__dir__)
-TMP_ROOT  = TEST_ROOT.join("..").expand_path.join("tmp")
+TMP_ROOT  = TEST_ROOT.join("..").join("tmp")
+TMP_APP_ROOT = TMP_ROOT.join("app")
 
 Time.zone = "Pacific Time (US & Canada)" # For Time.zone.now.
 
@@ -31,7 +32,7 @@ end
 
 AppProfiler.tap do |config|
   config.logger       = Logger.new("/dev/null")
-  config.root         = TEST_ROOT
+  config.root         = TMP_APP_ROOT
   config.profile_root = TMP_ROOT
 end
 


### PR DESCRIPTION
Fixes bug where apps with speedscope still `yarn add` when viewing a profile.