### PR TITLE
Update rubocop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,9 +6,3 @@
 /pkg/
 /spec/reports/
 /tmp/
-
-# rspec failure tracking
-.rspec_status
-
-# Ignore RuboCop cache
-.rubocop-http---shopify-github-io-ruby-style-guide-rubocop-yml

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
-inherit_from:
-  - http://shopify.github.io/ruby-style-guide/rubocop.yml
+inherit_gem:
+  rubocop-shopify: rubocop.yml
 
 require: rubocop-performance
 

--- a/Gemfile
+++ b/Gemfile
@@ -8,5 +8,6 @@ gem("activesupport", "~> 5.2")
 gem("railties", "~> 5.2")
 
 gem("google-cloud-storage", "~> 1.21")
-gem("rubocop")
-gem("rubocop-performance")
+gem("rubocop", require: false)
+gem("rubocop-shopify", require: false)
+gem("rubocop-performance", require: false)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,7 +30,7 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
-    ast (2.4.0)
+    ast (2.4.2)
     builder (3.2.4)
     concurrent-ruby (1.1.6)
     crass (1.0.6)
@@ -87,9 +87,9 @@ GEM
     nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
     os (1.1.0)
-    parallel (1.19.1)
-    parser (2.7.1.2)
-      ast (~> 2.4.0)
+    parallel (1.20.1)
+    parser (3.0.0.0)
+      ast (~> 2.4.1)
     public_suffix (4.0.5)
     rack (2.2.2)
     rack-test (1.1.0)
@@ -107,25 +107,29 @@ GEM
       thor (>= 0.19.0, < 2.0)
     rainbow (3.0.0)
     rake (13.0.1)
+    regexp_parser (2.0.3)
     representable (3.0.4)
       declarative (< 0.1.0)
       declarative-option (< 0.2.0)
       uber (< 0.2.0)
     retriable (3.1.2)
     rexml (3.2.4)
-    rubocop (0.84.0)
+    rubocop (1.10.0)
       parallel (~> 1.10)
-      parser (>= 2.7.0.1)
+      parser (>= 3.0.0.0)
       rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
       rexml
-      rubocop-ast (>= 0.0.3)
+      rubocop-ast (>= 1.2.0, < 2.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 1.4.0, < 2.0)
-    rubocop-ast (0.0.3)
-      parser (>= 2.7.0.1)
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.4.1)
+      parser (>= 2.7.1.5)
     rubocop-performance (1.6.0)
       rubocop (>= 0.71.0)
-    ruby-progressbar (1.10.1)
+    rubocop-shopify (1.0.7)
+      rubocop (~> 1.4)
+    ruby-progressbar (1.11.0)
     signet (0.14.0)
       addressable (~> 2.3)
       faraday (>= 0.17.3, < 2.0)
@@ -137,7 +141,7 @@ GEM
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
     uber (0.1.0)
-    unicode-display_width (1.7.0)
+    unicode-display_width (2.0.0)
 
 PLATFORMS
   ruby
@@ -154,6 +158,7 @@ DEPENDENCIES
   rake
   rubocop
   rubocop-performance
+  rubocop-shopify
 
 BUNDLED WITH
    2.1.4

--- a/lib/app_profiler/viewer/speedscope_viewer.rb
+++ b/lib/app_profiler/viewer/speedscope_viewer.rb
@@ -14,6 +14,7 @@ module AppProfiler
       end
 
       def initialize(profile)
+        super()
         @profile = profile
       end
 

--- a/test/app_profiler/profiler_test.rb
+++ b/test/app_profiler/profiler_test.rb
@@ -7,7 +7,7 @@ module AppProfiler
     test ".run prints error when failed" do
       AppProfiler.logger.expects(:info).with { |value| value =~ /failed to start the profiler/ }
       profile = Profiler.run(mode: :unsupported) do
-        sleep 0.1
+        sleep(0.1)
       end
 
       assert_nil(profile)
@@ -17,7 +17,7 @@ module AppProfiler
       error = StandardError.new("An error occurred.")
       exception = assert_raises(StandardError) do
         Profiler.run(stackprof_profile) do
-          assert_predicate Profiler, :running?
+          assert_predicate(Profiler, :running?)
           raise error
         end
       end
@@ -32,7 +32,7 @@ module AppProfiler
       assert_equal(true, Profiler.send(:start, stackprof_profile))
 
       profile = Profiler.run(stackprof_profile) do
-        sleep 0.1
+        sleep(0.1)
       end
 
       assert_nil(profile)
@@ -43,7 +43,7 @@ module AppProfiler
 
     test "cpu profile by default" do
       profile = Profiler.run(stackprof_profile) do
-        sleep 0.1
+        sleep(0.1)
       end
 
       assert_instance_of(AppProfiler::Profile, profile)
@@ -53,7 +53,7 @@ module AppProfiler
 
     test "assigns id and context to profiles" do
       profile = Profiler.run(stackprof_profile(metadata: { id: "wowza", context: "bar" })) do
-        sleep 0.1
+        sleep(0.1)
       end
 
       assert_instance_of(AppProfiler::Profile, profile)
@@ -63,7 +63,7 @@ module AppProfiler
 
     test "cpu profile" do
       profile = Profiler.run(stackprof_profile(mode: :cpu, interval: 2000)) do
-        sleep 0.1
+        sleep(0.1)
       end
 
       assert_instance_of(AppProfiler::Profile, profile)
@@ -73,7 +73,7 @@ module AppProfiler
 
     test "wall profile" do
       profile = Profiler.run(stackprof_profile(mode: :wall, interval: 2000)) do
-        sleep 0.1
+        sleep(0.1)
       end
 
       assert_instance_of(AppProfiler::Profile, profile)
@@ -83,7 +83,7 @@ module AppProfiler
 
     test "object profile" do
       profile = Profiler.run(stackprof_profile(mode: :object, interval: 2)) do
-        sleep 0.1
+        sleep(0.1)
       end
 
       assert_instance_of(AppProfiler::Profile, profile)

--- a/test/app_profiler/run_test.rb
+++ b/test/app_profiler/run_test.rb
@@ -6,7 +6,7 @@ module AppProfiler
   class RunTest < TestCase
     test ".run delegates to Profiler.run" do
       profile = AppProfiler.run(stackprof_profile(mode: :cpu, interval: 2000)) do
-        sleep 0.1
+        sleep(0.1)
       end
 
       assert_instance_of(AppProfiler::Profile, profile)


### PR DESCRIPTION
Fix rubocop CI failures by sourcing it properly and updating cops.