### PR TITLE
Assign ownership of app_profiler to sysperf team

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -1,3 +1,10 @@
 classification: library
 slack_channels:
 - webscale
+
+org_line: Production Engineering
+owners:
+  - Shopify/sysperf
+url: https://development.shopify.io/engineering/production/performance/profiling/
+slack_channels:
+  - team-sysperf

--- a/service.yml
+++ b/service.yml
@@ -1,7 +1,4 @@
 classification: library
-slack_channels:
-- webscale
-
 org_line: Production Engineering
 owners:
   - Shopify/sysperf


### PR DESCRIPTION
The webscale team no longer exists, and the sysperf team has the most overlap in knowledge
and interests to take on routine maintenance (gem bumps, etc).

cc @honkfestival 