### PR TITLE
Add File Safe Regex to Profile Filename

### DIFF
--- a/lib/app_profiler/profile.rb
+++ b/lib/app_profiler/profile.rb
@@ -4,6 +4,7 @@ module AppProfiler
   class Profile
     INTERNAL_METADATA_KEYS = %i(id context)
     private_constant :INTERNAL_METADATA_KEYS
+    class UnsafeFilename < StandardError; end
 
     delegate    :[], to: :@data
     attr_reader :id, :context
@@ -69,6 +70,8 @@ module AppProfiler
         id,
         Socket.gethostname,
       ].compact.join("-") << ".json"
+
+      raise UnsafeFilename if %r{[^0-9A-Za-z.\-\_]}.match(filename)
 
       AppProfiler.profile_root.join(filename)
     end

--- a/lib/app_profiler/profile.rb
+++ b/lib/app_profiler/profile.rb
@@ -71,7 +71,7 @@ module AppProfiler
         Socket.gethostname,
       ].compact.join("-") << ".json"
 
-      raise UnsafeFilename if %r{[^0-9A-Za-z.\-\_]}.match(filename)
+      raise UnsafeFilename if /[^0-9A-Za-z.\-\_]/.match(filename)
 
       AppProfiler.profile_root.join(filename)
     end

--- a/test/app_profiler/profile_test.rb
+++ b/test/app_profiler/profile_test.rb
@@ -137,5 +137,12 @@ module AppProfiler
 
       assert_equal(10_000, profile[:interval])
     end
+
+    test "#path raises an UnsafeFilename exception given chars not in allow list" do
+      assert_raises(AppProfiler::Profile::UnsafeFilename) do
+        profile = Profile.from_stackprof(stackprof_profile(metadata: { id: "|`@${}", context: "bar" }))
+        profile.file
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR aims to add a regex which will enforce an allowed list of characters on the profile filenames generated by the App Profiler.

https://github.com/Shopify/app_profiler/blob/4d4ed61eec62e047238c80d0e3e72d256594daa8/lib/app_profiler/profile.rb#L66-L77

The regex `[^0-9A-Za-z.\-\_]`, attempts to match on any character **not** included in alphanumerics, `.`, `-` or `_`.