### PR TITLE
Add speedscope remote viewer

### DIFF
--- a/lib/app_profiler.rb
+++ b/lib/app_profiler.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
-require "active_support"
+require "active_support/core_ext/class"
+require "active_support/core_ext/module"
+require "logger"
 require "app_profiler/version"
 require "app_profiler/railtie" if defined?(Rails::Railtie)
 
@@ -17,6 +19,7 @@ module AppProfiler
   module Viewer
     autoload :BaseViewer, "app_profiler/viewer/base_viewer"
     autoload :SpeedscopeViewer, "app_profiler/viewer/speedscope_viewer"
+    autoload :SpeedscopeRemoteViewer, "app_profiler/viewer/speedscope_remote_viewer"
   end
 
   autoload :Middleware, "app_profiler/middleware"

--- a/lib/app_profiler/railtie.rb
+++ b/lib/app_profiler/railtie.rb
@@ -30,6 +30,9 @@ module AppProfiler
 
     initializer "app_profiler.add_middleware" do |app|
       unless AppProfiler.middleware.disabled
+        if AppProfiler.viewer == Viewer::SpeedscopeRemoteViewer
+          app.middleware.insert_before(0, Viewer::SpeedscopeRemoteViewer::Middleware)
+        end
         app.middleware.insert_before(0, AppProfiler.middleware)
       end
     end

--- a/lib/app_profiler/viewer/base_viewer.rb
+++ b/lib/app_profiler/viewer/base_viewer.rb
@@ -3,7 +3,13 @@
 module AppProfiler
   module Viewer
     class BaseViewer
-      def self.view(_profile)
+      class << self
+        def view(profile)
+          new(profile).view
+        end
+      end
+
+      def view(_profile)
         raise NotImplementedError
       end
     end

--- a/lib/app_profiler/viewer/speedscope_remote_viewer.rb
+++ b/lib/app_profiler/viewer/speedscope_remote_viewer.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "app_profiler/viewer/speedscope_remote_viewer/base_middleware"
+require "app_profiler/viewer/speedscope_remote_viewer/middleware"
+
+module AppProfiler
+  module Viewer
+    class SpeedscopeRemoteViewer < BaseViewer
+      class << self
+        def view(profile)
+          new(profile).view
+        end
+      end
+
+      def initialize(profile)
+        super()
+        @profile = profile
+      end
+
+      def view
+        id = Middleware.id(@profile.file)
+        AppProfiler.logger.info("[Profiler] Profile available at /app_profiler/#{id}\n")
+      end
+    end
+  end
+end

--- a/lib/app_profiler/viewer/speedscope_remote_viewer/base_middleware.rb
+++ b/lib/app_profiler/viewer/speedscope_remote_viewer/base_middleware.rb
@@ -8,8 +8,9 @@ module AppProfiler
       class BaseMiddleware
         class Sanitizer < Rails::Html::SafeListSanitizer
           self.allowed_tags = Set.new(%w(strong em b i p code pre tt samp kbd var sub
-          sup dfn cite big small address hr br div span h1 h2 h3 h4 h5 h6 ul ol li dl dt dd abbr
-          acronym a img blockquote del ins script))
+                                         sup dfn cite big small address hr br div span
+                                         h1 h2 h3 h4 h5 h6 ul ol li dl dt dd abbr
+                                         acronym a img blockquote del ins script))
         end
 
         private_constant(:Sanitizer)

--- a/lib/app_profiler/viewer/speedscope_remote_viewer/base_middleware.rb
+++ b/lib/app_profiler/viewer/speedscope_remote_viewer/base_middleware.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require "rails-html-sanitizer"
+
+module AppProfiler
+  module Viewer
+    class SpeedscopeRemoteViewer < BaseViewer
+      class BaseMiddleware
+        class Sanitizer < Rails::Html::SafeListSanitizer
+          self.allowed_tags = Set.new(%w(strong em b i p code pre tt samp kbd var sub
+          sup dfn cite big small address hr br div span h1 h2 h3 h4 h5 h6 ul ol li dl dt dd abbr
+          acronym a img blockquote del ins script))
+        end
+
+        private_constant(:Sanitizer)
+
+        def self.id(file)
+          file.basename.to_s.delete_suffix(".json")
+        end
+
+        def initialize(app)
+          @app = app
+        end
+
+        def call(env)
+          request = Rack::Request.new(env)
+
+          return index(env)                        if request.path_info =~ %r(\A/app_profiler\z)
+          return viewer(env, Regexp.last_match(1)) if request.path_info =~ %r(\A/app_profiler/viewer/(.*)\z)
+          return show(env, Regexp.last_match(1))   if request.path_info =~ %r(\A/app_profiler/(.*)\z)
+
+          @app.call(env)
+        end
+
+        protected
+
+        def id(file)
+          self.class.id(file)
+        end
+
+        def profile_files
+          AppProfiler.profile_root.glob("**/*.json")
+        end
+
+        def render(html)
+          [
+            200,
+            { "Content-Type" => "text/html" },
+            [
+              +<<~HTML,
+                <!doctype html>
+                <html>
+                  <head>
+                    <title>App Profiler</title>
+                  </head>
+                  <body>
+                    #{sanitizer.sanitize(html)}
+                  </body>
+                </html>
+              HTML
+            ],
+          ]
+        end
+
+        def sanitizer
+          @sanitizer ||= Sanitizer.new
+        end
+
+        def viewer(_env, path)
+          raise NotImplementedError
+        end
+
+        def index(_env)
+          render(
+            String.new.tap do |content|
+              content << "<h1>Profiles</h1>"
+              profile_files.each do |file|
+                content << <<~HTML
+                  <p>
+                    <a href="/app_profiler/#{id(file)}">
+                      #{id(file)}
+                    </a>
+                  </p>
+                HTML
+              end
+            end
+          )
+        end
+
+        def show(env, id)
+          raise NotImplementedError
+        end
+      end
+
+      private_constant(:BaseMiddleware)
+    end
+  end
+end

--- a/lib/app_profiler/viewer/speedscope_remote_viewer/middleware.rb
+++ b/lib/app_profiler/viewer/speedscope_remote_viewer/middleware.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "app_profiler/yarn/command"
+require "app_profiler/yarn/with_speedscope"
+
+module AppProfiler
+  module Viewer
+    class SpeedscopeRemoteViewer < BaseViewer
+      class Middleware < BaseMiddleware
+        include Yarn::WithSpeedscope
+
+        def initialize(app)
+          super
+          @speedscope = Rack::File.new(
+            File.join(AppProfiler.root, "node_modules/speedscope/dist/release")
+          )
+        end
+
+        protected
+
+        attr_reader(:speedscope)
+
+        def viewer(env, path)
+          setup_yarn unless yarn_setup
+          env[Rack::PATH_INFO] = path.delete_prefix("/app_profiler")
+
+          speedscope.call(env)
+        end
+
+        def show(_env, name)
+          profile = profile_files.find do |file|
+            id(file) == name
+          end || raise(ArgumentError)
+
+          render(
+            <<~HTML
+              <script type="text/javascript">
+                var graph = #{profile.read};
+                var json = JSON.stringify(graph);
+                var blob = new Blob([json], { type: 'text/plain' });
+                var objUrl = encodeURIComponent(URL.createObjectURL(blob));
+                var iframe = document.createElement('iframe');
+
+                document.body.style.margin = '0px';
+                document.body.appendChild(iframe);
+
+                iframe.style.width = '100vw';
+                iframe.style.height = '100vh';
+                iframe.style.border = 'none';
+                iframe.setAttribute('src', '/app_profiler/viewer/index.html#profileURL=' + objUrl + '&title=' + 'Flamegraph for #{name}');
+              </script>
+            HTML
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/app_profiler/viewer/speedscope_viewer.rb
+++ b/lib/app_profiler/viewer/speedscope_viewer.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
 
+require "app_profiler/yarn/command"
+require "app_profiler/yarn/with_speedscope"
+
 module AppProfiler
   module Viewer
     class SpeedscopeViewer < BaseViewer
-      mattr_accessor :yarn_setup, default: false
-
-      class YarnError < StandardError; end
+      include Yarn::WithSpeedscope
 
       class << self
         def view(profile)
@@ -20,51 +21,6 @@ module AppProfiler
 
       def view
         yarn("run speedscope \"#{@profile.file}\"")
-      end
-
-      private
-
-      def yarn(command)
-        setup_yarn unless yarn_setup
-        exec("yarn #{command}") do
-          raise YarnError, "Failed to run #{command}."
-        end
-      end
-
-      def setup_yarn
-        ensure_yarn_installed
-        yarn("init --yes") unless package_json_exists?
-        # We currently only support this gem in the root Gemfile.
-        # See https://github.com/Shopify/app_profiler/issues/15
-        # for more information
-        yarn("add --dev --ignore-workspace-root-check speedscope") unless speedscope_added?
-      end
-
-      def ensure_yarn_installed
-        exec("which yarn > /dev/null") do
-          raise(
-            YarnError,
-            <<~MSG.squish
-              `yarn` command not found.
-              Please install `yarn` or make it available in PATH.
-            MSG
-          )
-        end
-        self.yarn_setup = true
-      end
-
-      def package_json_exists?
-        AppProfiler.root.join("package.json").exist?
-      end
-
-      def speedscope_added?
-        AppProfiler.root.join("node_modules/speedscope").exist?
-      end
-
-      def exec(command)
-        system(command).tap do |return_code|
-          yield unless return_code
-        end
       end
     end
   end

--- a/lib/app_profiler/viewer/speedscope_viewer.rb
+++ b/lib/app_profiler/viewer/speedscope_viewer.rb
@@ -20,7 +20,7 @@ module AppProfiler
       end
 
       def view
-        yarn("run speedscope \"#{@profile.file}\"")
+        yarn("run", "speedscope", "\"#{@profile.file}\"")
       end
     end
   end

--- a/lib/app_profiler/yarn/command.rb
+++ b/lib/app_profiler/yarn/command.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+module AppProfiler
+  module Yarn
+    module Command
+      class YarnError < StandardError; end
+
+      mattr_accessor :yarn_setup, default: false
+
+      def yarn(command)
+        setup_yarn unless yarn_setup
+        exec("yarn #{command}") do
+          raise YarnError, "Failed to run #{command}."
+        end
+      end
+
+      def setup_yarn
+        ensure_yarn_installed
+        yarn("init --yes") unless package_json_exists?
+      end
+
+      private
+
+      def ensure_yarn_installed
+        exec("which yarn > /dev/null") do
+          raise(
+            YarnError,
+            <<~MSG.squish
+              `yarn` command not found.
+              Please install `yarn` or make it available in PATH.
+            MSG
+          )
+        end
+        self.yarn_setup = true
+      end
+
+      def package_json_exists?
+        AppProfiler.root.join("package.json").exist?
+      end
+
+      def exec(command)
+        system(command).tap do |return_code|
+          yield unless return_code
+        end
+      end
+    end
+  end
+end

--- a/lib/app_profiler/yarn/with_speedscope.rb
+++ b/lib/app_profiler/yarn/with_speedscope.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+module AppProfiler
+  module Yarn
+    module WithSpeedscope
+      include Command
+
+      def setup_yarn
+        super
+        # We currently only support this gem in the root Gemfile.
+        # See https://github.com/Shopify/app_profiler/issues/15
+        # for more information
+        yarn("add --dev --ignore-workspace-root-check speedscope") unless speedscope_added?
+      end
+
+      private
+
+      def speedscope_added?
+        AppProfiler.root.join("node_modules/speedscope").exist?
+      end
+    end
+  end
+end

--- a/lib/app_profiler/yarn/with_speedscope.rb
+++ b/lib/app_profiler/yarn/with_speedscope.rb
@@ -9,7 +9,7 @@ module AppProfiler
         # We currently only support this gem in the root Gemfile.
         # See https://github.com/Shopify/app_profiler/issues/15
         # for more information
-        yarn("add --dev --ignore-workspace-root-check speedscope") unless speedscope_added?
+        yarn("add", "speedscope", "--dev", "--ignore-workspace-root-check") unless speedscope_added?
       end
 
       private

--- a/test/app_profiler/viewer/speedscope_remote_viewer/middleware_test.rb
+++ b/test/app_profiler/viewer/speedscope_remote_viewer/middleware_test.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module AppProfiler
+  module Viewer
+    class SpeedscopeRemoteViewer
+      class MiddlewareTest < TestCase
+        setup do
+          @app = Middleware.new(
+            proc { [200, { "Content-Type" => "text/plain" }, ["Hello world!"]] }
+          )
+        end
+
+        test ".id" do
+          profile = Profile.new(stackprof_profile)
+          profile_id = profile.file.basename.to_s.delete_suffix(".json")
+
+          assert_equal(profile_id, Middleware.id(profile.file))
+        end
+
+        test "#call index" do
+          profiles = 3.times.map { Profile.new(stackprof_profile).tap(&:file) }
+
+          code, content_type, html = @app.call({ "PATH_INFO" => "/app_profiler" })
+          html = html.first
+
+          assert_equal(200, code)
+          assert_equal({ "Content-Type" => "text/html" }, content_type)
+          assert_match(%r(<title>App Profiler</title>), html)
+          profiles.each do |profile|
+            assert_match(%r(<a href="/app_profiler/#{Middleware.id(profile.file)}">), html)
+          end
+        end
+
+        test "#call show" do
+          profile = Profile.new(stackprof_profile)
+          id = Middleware.id(profile.file)
+
+          code, content_type, html = @app.call({ "PATH_INFO" => "/app_profiler/#{id}" })
+          html = html.first
+
+          assert_equal(200, code)
+          assert_equal({ "Content-Type" => "text/html" }, content_type)
+          assert_match(%r(<title>App Profiler</title>), html)
+          assert_match(%r(<script type="text/javascript">), html)
+        end
+
+        test "#call viewer sets up yarn" do
+          @app.expects(:system).with("which yarn > /dev/null").returns(true)
+          @app.expects(:system).with("yarn init --yes").returns(true)
+          @app.expects(:system).with("yarn add --dev --ignore-workspace-root-check speedscope").returns(true)
+
+          @app.call({ "PATH_INFO" => "/app_profiler/viewer/index.html" })
+
+          assert_predicate(Yarn::Command, :yarn_setup)
+        ensure
+          Yarn::Command.yarn_setup = false
+        end
+
+        test "#call viewer" do
+          with_yarn_setup do
+            @app.expects(:speedscope).returns(proc { [200, { "Content-Type" => "text/plain" }, ["Speedscope"]] })
+
+            response = @app.call({ "PATH_INFO" => "/app_profiler/viewer/index.html" })
+
+            assert_equal([200, { "Content-Type" => "text/plain" }, ["Speedscope"]], response)
+          end
+        end
+
+        test "#call" do
+          response = @app.call({ "PATH_INFO" => "/app_level_route" })
+
+          assert_equal([200, { "Content-Type" => "text/plain" }, ["Hello world!"]], response)
+        end
+      end
+    end
+  end
+end

--- a/test/app_profiler/viewer/speedscope_remote_viewer/middleware_test.rb
+++ b/test/app_profiler/viewer/speedscope_remote_viewer/middleware_test.rb
@@ -47,9 +47,11 @@ module AppProfiler
         end
 
         test "#call viewer sets up yarn" do
-          @app.expects(:system).with("which yarn > /dev/null").returns(true)
-          @app.expects(:system).with("yarn init --yes").returns(true)
-          @app.expects(:system).with("yarn add --dev --ignore-workspace-root-check speedscope").returns(true)
+          @app.expects(:system).with("which", "yarn > /dev/null").returns(true)
+          @app.expects(:system).with("yarn", "init", "--yes").returns(true)
+          @app.expects(:system).with(
+            "yarn", "add", "speedscope", "--dev", "--ignore-workspace-root-check"
+          ).returns(true)
 
           @app.call({ "PATH_INFO" => "/app_profiler/viewer/index.html" })
 

--- a/test/app_profiler/viewer/speedscope_remote_viewer_test.rb
+++ b/test/app_profiler/viewer/speedscope_remote_viewer_test.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module AppProfiler
+  module Viewer
+    class SpeedscopeRemoteViewerTest < TestCase
+      test ".view initializes and calls #view" do
+        SpeedscopeRemoteViewer.any_instance.expects(:view)
+
+        profile = Profile.new(stackprof_profile)
+        SpeedscopeRemoteViewer.view(profile)
+      end
+
+      test "#view logs middleware URL" do
+        profile = Profile.new(stackprof_profile)
+
+        viewer = SpeedscopeRemoteViewer.new(profile)
+        id = SpeedscopeRemoteViewer::Middleware.id(profile.file)
+
+        AppProfiler.logger.expects(:info).with(
+          "[Profiler] Profile available at /app_profiler/#{id}\n"
+        )
+
+        viewer.view
+      end
+
+      private
+
+      def with_yarn_setup
+        old_yarn_setup = Yarn::Command.yarn_setup
+        Yarn::Command.yarn_setup = true
+        yield
+      ensure
+        Yarn::Command.yarn_setup = old_yarn_setup
+      end
+    end
+  end
+end

--- a/test/app_profiler/viewer/speedscope_viewer_test.rb
+++ b/test/app_profiler/viewer/speedscope_viewer_test.rb
@@ -16,10 +16,12 @@ module AppProfiler
         profile = Profile.new(stackprof_profile)
 
         viewer = SpeedscopeViewer.new(profile)
-        viewer.expects(:system).with("which yarn > /dev/null").returns(true)
-        viewer.expects(:system).with("yarn init --yes").returns(true)
-        viewer.expects(:system).with("yarn add --dev --ignore-workspace-root-check speedscope").returns(true)
-        viewer.expects(:system).with("yarn run speedscope \"#{profile.file}\"").returns(true)
+        viewer.expects(:system).with("which", "yarn > /dev/null").returns(true)
+        viewer.expects(:system).with("yarn", "init", "--yes").returns(true)
+        viewer.expects(:system).with(
+          "yarn", "add", "speedscope", "--dev", "--ignore-workspace-root-check"
+        ).returns(true)
+        viewer.expects(:system).with("yarn", "run", "speedscope", "\"#{profile.file}\"").returns(true)
 
         viewer.view
 
@@ -35,9 +37,11 @@ module AppProfiler
         AppProfiler.root.join("package.json").write("{}")
 
         viewer = SpeedscopeViewer.new(profile)
-        viewer.expects(:system).with("which yarn > /dev/null").returns(true)
-        viewer.expects(:system).with("yarn add --dev --ignore-workspace-root-check speedscope").returns(true)
-        viewer.expects(:system).with("yarn run speedscope \"#{profile.file}\"").returns(true)
+        viewer.expects(:system).with("which", "yarn > /dev/null").returns(true)
+        viewer.expects(:system).with(
+          "yarn", "add", "speedscope", "--dev", "--ignore-workspace-root-check"
+        ).returns(true)
+        viewer.expects(:system).with("yarn", "run", "speedscope", "\"#{profile.file}\"").returns(true)
 
         viewer.view
 
@@ -54,9 +58,9 @@ module AppProfiler
         AppProfiler.root.join("node_modules/speedscope").mkpath
 
         viewer = SpeedscopeViewer.new(profile)
-        viewer.expects(:system).with("which yarn > /dev/null").returns(true)
-        viewer.expects(:system).with("yarn init --yes").returns(true)
-        viewer.expects(:system).with("yarn run speedscope \"#{profile.file}\"").returns(true)
+        viewer.expects(:system).with("which", "yarn > /dev/null").returns(true)
+        viewer.expects(:system).with("yarn", "init", "--yes").returns(true)
+        viewer.expects(:system).with("yarn", "run", "speedscope", "\"#{profile.file}\"").returns(true)
 
         viewer.view
 
@@ -71,7 +75,7 @@ module AppProfiler
 
         with_yarn_setup do
           viewer = SpeedscopeViewer.new(profile)
-          viewer.expects(:system).with("yarn run speedscope \"#{profile.file}\"").returns(true)
+          viewer.expects(:system).with("yarn", "run", "speedscope", "\"#{profile.file}\"").returns(true)
 
           viewer.view
         end

--- a/test/app_profiler/viewer/speedscope_viewer_test.rb
+++ b/test/app_profiler/viewer/speedscope_viewer_test.rb
@@ -23,9 +23,9 @@ module AppProfiler
 
         viewer.view
 
-        assert_predicate(SpeedscopeViewer, :yarn_setup)
+        assert_predicate(Yarn::Command, :yarn_setup)
       ensure
-        SpeedscopeViewer.yarn_setup = false
+        Yarn::Command.yarn_setup = false
       end
 
       test "#view doesn't init when package.json exists" do
@@ -41,9 +41,9 @@ module AppProfiler
 
         viewer.view
 
-        assert_predicate(SpeedscopeViewer, :yarn_setup)
+        assert_predicate(Yarn::Command, :yarn_setup)
       ensure
-        SpeedscopeViewer.yarn_setup = false
+        Yarn::Command.yarn_setup = false
         AppProfiler.root.rmtree
       end
 
@@ -60,9 +60,9 @@ module AppProfiler
 
         viewer.view
 
-        assert_predicate(SpeedscopeViewer, :yarn_setup)
+        assert_predicate(Yarn::Command, :yarn_setup)
       ensure
-        SpeedscopeViewer.yarn_setup = false
+        Yarn::Command.yarn_setup = false
         AppProfiler.root.rmtree
       end
 
@@ -85,16 +85,6 @@ module AppProfiler
         assert_raises(SpeedscopeViewer::YarnError) do
           viewer.view
         end
-      end
-
-      private
-
-      def with_yarn_setup
-        old_yarn_setup = SpeedscopeViewer.yarn_setup
-        SpeedscopeViewer.yarn_setup = true
-        yield
-      ensure
-        SpeedscopeViewer.yarn_setup = old_yarn_setup
       end
     end
   end

--- a/test/app_profiler/yarn/command_test.rb
+++ b/test/app_profiler/yarn/command_test.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module AppProfiler
+  module Yarn
+    class CommandTest < TestCase
+      include(Command)
+
+      setup do
+        Command.yarn_setup = true
+      end
+
+      teardown do
+        Command.yarn_setup = false
+      end
+
+      test "#yarn allows add speedscope" do
+        expects(:system).with(
+          "yarn", "add", "speedscope", "--dev", "--ignore-workspace-root-check"
+        ).returns(true)
+
+        yarn("add", "speedscope", "--dev", "--ignore-workspace-root-check")
+      end
+
+      test "#yarn allows init" do
+        expects(:system).with("yarn", "init", "--yes").returns(true)
+
+        yarn("init", "--yes")
+      end
+
+      test "#yarn allows run" do
+        expects(:system).with("yarn", "run", "speedscope", "\"profile.json\"").returns(true)
+
+        yarn("run", "speedscope", "\"profile.json\"")
+      end
+
+      test "#yarn disallows run" do
+        expects(:system).with("yarn", "hack").never
+
+        error = assert_raises(Command::YarnError) do
+          yarn("hack")
+        end
+
+        assert_equal(<<~MSG.squish, error.message)
+          Illegal command: yarn hack.
+        MSG
+      end
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -51,5 +51,13 @@ module AppProfiler
     def stackprof_profile(params = {})
       { mode: :cpu, interval: 1000, frames: [], metadata: { id: "foo" } }.merge(params)
     end
+
+    def with_yarn_setup
+      old_yarn_setup = Yarn::Command.yarn_setup
+      Yarn::Command.yarn_setup = true
+      yield
+    ensure
+      Yarn::Command.yarn_setup = old_yarn_setup
+    end
   end
 end


### PR DESCRIPTION
Adds remote speedscope viewer for profiling on remote hosts. It uses rack middleware to hijack `/app_profiler` requests to list and view profiles of a booted rack / rails app. Very similar to what rack mini profiler does.

The routes are:

`/app_profiler` to list profiles
`/app_profiler/{id}` to show a specific profile in speedscope
`/app_profiler/viewer/index.html` to mount speedscope via `Rack::File`