### PR TITLE
Fix exec calls

### DIFF
--- a/lib/app_profiler/viewer/speedscope_viewer.rb
+++ b/lib/app_profiler/viewer/speedscope_viewer.rb
@@ -20,7 +20,7 @@ module AppProfiler
       end
 
       def view
-        yarn("run", "speedscope", "\"#{@profile.file}\"")
+        yarn("run", "speedscope", @profile.file.to_s)
       end
     end
   end

--- a/test/app_profiler/viewer/speedscope_remote_viewer/middleware_test.rb
+++ b/test/app_profiler/viewer/speedscope_remote_viewer/middleware_test.rb
@@ -47,7 +47,7 @@ module AppProfiler
         end
 
         test "#call viewer sets up yarn" do
-          @app.expects(:system).with("which", "yarn > /dev/null").returns(true)
+          @app.expects(:system).with("which", "yarn", out: File::NULL).returns(true)
           @app.expects(:system).with("yarn", "init", "--yes").returns(true)
           @app.expects(:system).with(
             "yarn", "add", "speedscope", "--dev", "--ignore-workspace-root-check"

--- a/test/app_profiler/viewer/speedscope_viewer_test.rb
+++ b/test/app_profiler/viewer/speedscope_viewer_test.rb
@@ -16,12 +16,12 @@ module AppProfiler
         profile = Profile.new(stackprof_profile)
 
         viewer = SpeedscopeViewer.new(profile)
-        viewer.expects(:system).with("which", "yarn > /dev/null").returns(true)
+        viewer.expects(:system).with("which", "yarn", out: File::NULL).returns(true)
         viewer.expects(:system).with("yarn", "init", "--yes").returns(true)
         viewer.expects(:system).with(
           "yarn", "add", "speedscope", "--dev", "--ignore-workspace-root-check"
         ).returns(true)
-        viewer.expects(:system).with("yarn", "run", "speedscope", "\"#{profile.file}\"").returns(true)
+        viewer.expects(:system).with("yarn", "run", "speedscope", profile.file.to_s).returns(true)
 
         viewer.view
 
@@ -37,11 +37,11 @@ module AppProfiler
         AppProfiler.root.join("package.json").write("{}")
 
         viewer = SpeedscopeViewer.new(profile)
-        viewer.expects(:system).with("which", "yarn > /dev/null").returns(true)
+        viewer.expects(:system).with("which", "yarn", out: File::NULL).returns(true)
         viewer.expects(:system).with(
           "yarn", "add", "speedscope", "--dev", "--ignore-workspace-root-check"
         ).returns(true)
-        viewer.expects(:system).with("yarn", "run", "speedscope", "\"#{profile.file}\"").returns(true)
+        viewer.expects(:system).with("yarn", "run", "speedscope", profile.file.to_s).returns(true)
 
         viewer.view
 
@@ -58,9 +58,9 @@ module AppProfiler
         AppProfiler.root.join("node_modules/speedscope").mkpath
 
         viewer = SpeedscopeViewer.new(profile)
-        viewer.expects(:system).with("which", "yarn > /dev/null").returns(true)
+        viewer.expects(:system).with("which", "yarn", out: File::NULL).returns(true)
         viewer.expects(:system).with("yarn", "init", "--yes").returns(true)
-        viewer.expects(:system).with("yarn", "run", "speedscope", "\"#{profile.file}\"").returns(true)
+        viewer.expects(:system).with("yarn", "run", "speedscope", profile.file.to_s).returns(true)
 
         viewer.view
 
@@ -75,7 +75,7 @@ module AppProfiler
 
         with_yarn_setup do
           viewer = SpeedscopeViewer.new(profile)
-          viewer.expects(:system).with("yarn", "run", "speedscope", "\"#{profile.file}\"").returns(true)
+          viewer.expects(:system).with("yarn", "run", "speedscope", profile.file.to_s).returns(true)
 
           viewer.view
         end


### PR DESCRIPTION
Fixes syntax of segmented `system` calls. These calls are made without shell context evaluation so `> /dev/null` and `""` aren't evaluated. This breaks yarn executable detection and speedscope profile opening. This PR fixes that.