### PR TITLE
Handle app_profiler index path with slash

### DIFF
--- a/lib/app_profiler/viewer/speedscope_remote_viewer/base_middleware.rb
+++ b/lib/app_profiler/viewer/speedscope_remote_viewer/base_middleware.rb
@@ -26,7 +26,7 @@ module AppProfiler
         def call(env)
           request = Rack::Request.new(env)
 
-          return index(env)                        if request.path_info =~ %r(\A/app_profiler\z)
+          return index(env)                        if request.path_info =~ %r(\A/app_profiler/?\z)
           return viewer(env, Regexp.last_match(1)) if request.path_info =~ %r(\A/app_profiler/viewer/(.*)\z)
           return show(env, Regexp.last_match(1))   if request.path_info =~ %r(\A/app_profiler/(.*)\z)
 

--- a/test/app_profiler/viewer/speedscope_remote_viewer/middleware_test.rb
+++ b/test/app_profiler/viewer/speedscope_remote_viewer/middleware_test.rb
@@ -33,6 +33,20 @@ module AppProfiler
           end
         end
 
+        test "#call index with slash" do
+          profiles = 3.times.map { Profile.new(stackprof_profile).tap(&:file) }
+
+          code, content_type, html = @app.call({ "PATH_INFO" => "/app_profiler/" })
+          html = html.first
+
+          assert_equal(200, code)
+          assert_equal({ "Content-Type" => "text/html" }, content_type)
+          assert_match(%r(<title>App Profiler</title>), html)
+          profiles.each do |profile|
+            assert_match(%r(<a href="/app_profiler/#{Middleware.id(profile.file)}">), html)
+          end
+        end
+
         test "#call show" do
           profile = Profile.new(stackprof_profile)
           id = Middleware.id(profile.file)


### PR DESCRIPTION
I was confused when I tried accessing `/app_profiler/` and got the following error:

```
Puma caught this error: ArgumentError (ArgumentError)
/usr/local/bundle/bundler/gems/app_profiler-7017e16d966a/lib/app_profiler/viewer/speedscope_remote_viewer/middleware.rb:33:in `show'
/usr/local/bundle/bundler/gems/app_profiler-7017e16d966a/lib/app_profiler/viewer/speedscope_remote_viewer/base_middleware.rb:31:in `call'
...
```

The problem is that the middleware only accepts `/app_profiler` and not `/app_profiler/` as the path, the latter is treated as a path to an actual profiler with a `name` value of `""`, which crashes with the exception above.

I just made a change to optionally accept `/app_profiler/` as well.