### PR TITLE
X-Profile-Data value is a string

### DIFF
--- a/lib/app_profiler/middleware/upload_action.rb
+++ b/lib/app_profiler/middleware/upload_action.rb
@@ -42,7 +42,7 @@ module AppProfiler
         end
 
         def profile_data_url(upload)
-          upload.url
+          upload.url.to_s
         end
 
         def profile_header

--- a/test/app_profiler/middleware/upload_action_test.rb
+++ b/test/app_profiler/middleware/upload_action_test.rb
@@ -44,6 +44,7 @@ module AppProfiler
 
         assert_predicate(@response[1][AppProfiler.profile_header], :present?)
         assert_predicate(@response[1][AppProfiler.profile_data_header], :present?)
+        assert_equal(@response[1][AppProfiler.profile_data_header].class, String)
         assert_predicate(@response[1]["Location"], :blank?)
         assert_equal(@response[0], 200)
       end


### PR DESCRIPTION
Some middlewares expect all of the response headers values to be `String` but X-Profile-Data is currently emitting a `Pathname`. This commit change it so that it is explicitly converted to a String, before sending the value downstream.

I ran into an issue specifically with [thin](https://github.com/macournoyer/thin/blob/v1.8.1/lib/thin/response.rb#L63-L77) where it was parsing the response headers and raised the following error:
```
Unexpected error while processing request: undefined method `each' for #<Pathname:0x000000010a196080>
```

Is there a reason to use Pathname over String?
