### PR TITLE
Support stackprof's ignore_gc option

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Rails.application.config.app_profiler.profile_header = "X-Profile"
 
 ### Here are some examples:
 
-1. `/?profile=cpu&interval=2000&autoredirect=1`
+1. `/?profile=cpu&interval=2000&autoredirect=1&ignore_gc=1`
 2. Set `X-Profile` to `mode=wall;interval=1000;context=test-directory;autoredirect=1`
 
 ### Possible keys:
@@ -50,6 +50,7 @@ Rails.application.config.app_profiler.profile_header = "X-Profile"
 | --- | ----- | ----- |
 | profile/mode | Supported profiling modes: `cpu`, `wall`, `object`. | Use `profile` in (1), and `mode` in (2). |
 | interval | Sampling interval in microseconds. | |
+| ignore_gc | Ignore garbage collection frames | |
 | autoredirect | Redirect request automatically to Speedscope's page after profiling. | |
 | context | Directory within the specified bucket in the selected storage where raw profile data should be written. | Only supported in (2). Defaults to `Rails.env` if not specified. |
 

--- a/lib/app_profiler/request_parameters.rb
+++ b/lib/app_profiler/request_parameters.rb
@@ -37,6 +37,7 @@ module AppProfiler
       {
         mode: mode.to_sym,
         interval: interval.to_i,
+        ignore_gc: !!ignore_gc,
         metadata: {
           id: request_id,
           context: context,
@@ -48,6 +49,10 @@ module AppProfiler
 
     def mode
       query_param("profile") || profile_header_param("mode")
+    end
+
+    def ignore_gc
+      query_param("ignore_gc") || profile_header_param("ignore_gc")
     end
 
     def interval

--- a/test/app_profiler/middleware_test.rb
+++ b/test/app_profiler/middleware_test.rb
@@ -74,6 +74,25 @@ module AppProfiler
       end
     end
 
+    test "ignore_gc option is supported" do
+      assert_profiles_dumped do
+        assert_profiles_uploaded do
+          middleware = AppProfiler::Middleware.new(app_env)
+          middleware.call(mock_request_env(path: "/?profile=cpu&ignore_gc=1"))
+        end
+      end
+    end
+
+    test "ignore_gc option through headers is supported" do
+      assert_profiles_dumped do
+        assert_profiles_uploaded do
+          middleware = AppProfiler::Middleware.new(app_env)
+          opt = { AppProfiler.request_profile_header => "mode=cpu;interval=2000;ignore_gc=1" }
+          middleware.call(mock_request_env(opt: opt))
+        end
+      end
+    end
+
     test "invalid profile mode will not profile" do
       assert_profiles_dumped(0) do
         AppProfiler.logger.expects(:info).with { |value| value =~ /unsupported profiling mode=hello/ }

--- a/test/app_profiler/request_parameters_test.rb
+++ b/test/app_profiler/request_parameters_test.rb
@@ -52,12 +52,12 @@ module AppProfiler
     test "#to_h return correct hash when request parameters are ok" do
       AppProfiler::RequestParameters::DEFAULT_INTERVALS.each do |mode, interval|
         params = request_params(headers: {
-          AppProfiler.request_profile_header => "mode=#{mode};interval=#{interval};context=test",
+          AppProfiler.request_profile_header => "mode=#{mode};interval=#{interval};context=test;ignore_gc=1",
           "HTTP_X_REQUEST_ID" => "123",
         })
 
         assert_equal(
-          { mode: mode.to_sym, interval: interval.to_i, metadata: { id: "123", context: "test" } },
+          { mode: mode.to_sym, interval: interval.to_i, ignore_gc: true, metadata: { id: "123", context: "test" } },
           params.to_h
         )
         assert_predicate(params, :valid?)


### PR DESCRIPTION
Allows the `ignore_gc` boolean option and passes it through to stackprof.

> By default, samples taken during garbage collection will show as garbage collection frames including both mark and sweep phases. For longer traces, these can leave gaps in a flamegraph that are hard to follow. They can be disabled by setting the ignore_gc option to true. Garbage collection time will still be present in the profile but not explicitly marked with its own frame.