### PR TITLE
Implement a simple, "HTTP" server and Rack app to initiate profiling remotely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [Unreleased]: https://github.com/Shopify/app_profiler
 
+- Support for "profile server" to support on-demand profiling via HTTP (#48)
 - Log info with link to speedscope during file upload (#47)
 
 ## [0.1.0] - 2022-04-18

--- a/README.md
+++ b/README.md
@@ -146,11 +146,13 @@ Alternatively, the server can be directly started with:
 AppProfiler::Server.start!
 ```
 
-The default duration, for requests without a duration parameter, can also be
+The default duration (in seconds), for requests without a duration parameter, can also be
 set via the railtie config.
 
 ```
-AppProfiler.server.duration
+AppProfiler.server.duration = 30
+# OR
+Rails.application.config.app_profiler.server_duration = 30
 ```
 
 The server supports both TCP and Unix sockets for its transport. It is
@@ -158,13 +160,17 @@ recommended to use TCP for local development, and Unix sockets for production:
 
 ```
 AppProfiler.server.transport = AppProfiler::Server::TRANSPORT_UNIX
+# OR
+Rails.application.config.app_profiler.server_transport = AppProfiler::Server::TRANSPORT_UNIX
 ```
 
 It is possible, but not recommended, to hardcode the listen port to be used in
 TCP server mode with:
 
 ```
-AppProfiler.server.port
+AppProfiler.server.port = 8080
+# OR
+Rails.application.config.app_profiler.server_port = 8080
 ```
 
 If this is done in production and it can cause port conflicts with multiple
@@ -203,14 +209,8 @@ $ echo $SOCK
 
 The API is very simple, and passes supported parameters directly to stackprof.
 
-Supported are:
-
-- mode: the stackprof mode to use [cpu, wall, object]
-- interval: the interval to use
-  - For cpu and wall, this will be the duration in microseconds between samples
-  - For object, this be the modulus of which allocations are counted. Eg, for
-1, every allocation is counted. For 10, only every tenth will be.
-- duration: how long the profiling session should last
+See the [possible keys](#possible-keys) for additional documentation on the
+supported parameters.
 
 For example, to collect a heap profile for 60 seconds, counting every 10th
 allocation:

--- a/lib/app_profiler.rb
+++ b/lib/app_profiler.rb
@@ -46,6 +46,7 @@ module AppProfiler
   mattr_accessor :storage, default: Storage::FileStorage
   mattr_accessor :viewer, default: Viewer::SpeedscopeViewer
   mattr_accessor :middleware, default: Middleware
+  mattr_accessor :server, default: Server
 
   class << self
     def run(*args, &block)

--- a/lib/app_profiler.rb
+++ b/lib/app_profiler.rb
@@ -30,6 +30,7 @@ module AppProfiler
   require "app_profiler/request_parameters"
   require "app_profiler/profiler"
   require "app_profiler/profile"
+  require "app_profiler/server"
 
   mattr_accessor :logger, default: Logger.new($stdout)
   mattr_accessor :root

--- a/lib/app_profiler/railtie.rb
+++ b/lib/app_profiler/railtie.rb
@@ -45,9 +45,9 @@ module AppProfiler
 
     initializer "app_profiler.enable_server" do
       if AppProfiler.server.enabled
-        AppProfiler::Server.start!
+        AppProfiler::Server.start
         ActiveSupport::ForkTracker.after_fork do
-          AppProfiler::Server.start!
+          AppProfiler::Server.start
         end
       end
     end

--- a/lib/app_profiler/railtie.rb
+++ b/lib/app_profiler/railtie.rb
@@ -17,6 +17,7 @@ module AppProfiler
       AppProfiler.middleware.action = app.config.app_profiler.middleware_action || default_middleware_action
       AppProfiler.middleware.disabled = app.config.app_profiler.middleware_disabled || false
       AppProfiler.server.enabled = app.config.app_profiler.server_enabled || false
+      AppProfiler.server.transport = app.config.app_profiler.server_transport || default_appprofiler_transport
       AppProfiler.server.port = app.config.app_profiler.server_port || 0
       AppProfiler.server.duration = app.config.app_profiler.server_duration || 30
       AppProfiler.server.cors = app.config.app_profiler.server_cors || true
@@ -53,6 +54,16 @@ module AppProfiler
         Middleware::ViewAction
       else
         Middleware::UploadAction
+      end
+    end
+
+    def default_appprofiler_transport
+      if Rails.env.development?
+        # default to TCP server in development so that if wanted users are able to target
+        # the server with speedscope
+        AppProfiler::Server::TRANSPORT_TCP
+      else
+        AppProfiler::Server::TRANSPORT_UNIX
       end
     end
   end

--- a/lib/app_profiler/railtie.rb
+++ b/lib/app_profiler/railtie.rb
@@ -44,7 +44,12 @@ module AppProfiler
     end
 
     initializer "app_profiler.enable_server" do
-      AppProfiler::Server.start! if AppProfiler.server.enabled
+      if AppProfiler.server.enabled
+        AppProfiler::Server.start!
+        ActiveSupport::ForkTracker.after_fork do
+          AppProfiler::Server.start!
+        end
+      end
     end
 
     private

--- a/lib/app_profiler/railtie.rb
+++ b/lib/app_profiler/railtie.rb
@@ -16,6 +16,9 @@ module AppProfiler
       AppProfiler.middleware = app.config.app_profiler.middleware || Middleware
       AppProfiler.middleware.action = app.config.app_profiler.middleware_action || default_middleware_action
       AppProfiler.middleware.disabled = app.config.app_profiler.middleware_disabled || false
+      AppProfiler.server.enabled = app.config.app_profiler.server_enabled || false
+      AppProfiler.server.port = app.config.app_profiler.server_port || 0
+      AppProfiler.server.duration = app.config.app_profiler.server_duration || 30
       AppProfiler.autoredirect = app.config.app_profiler.autoredirect || false
       AppProfiler.speedscope_host = app.config.app_profiler.speedscope_host || ENV.fetch(
         "APP_PROFILER_SPEEDSCOPE_URL", "https://speedscope.app"
@@ -35,6 +38,10 @@ module AppProfiler
         end
         app.middleware.insert_before(0, AppProfiler.middleware)
       end
+    end
+
+    initializer "app_profiler.enable_server" do
+      AppProfiler::Server.start! if AppProfiler.server.enabled
     end
 
     private

--- a/lib/app_profiler/railtie.rb
+++ b/lib/app_profiler/railtie.rb
@@ -19,6 +19,8 @@ module AppProfiler
       AppProfiler.server.enabled = app.config.app_profiler.server_enabled || false
       AppProfiler.server.port = app.config.app_profiler.server_port || 0
       AppProfiler.server.duration = app.config.app_profiler.server_duration || 30
+      AppProfiler.server.cors = app.config.app_profiler.server_cors || true
+      AppProfiler.server.cors_host = app.config.app_profiler.server_cors_host || "*"
       AppProfiler.autoredirect = app.config.app_profiler.autoredirect || false
       AppProfiler.speedscope_host = app.config.app_profiler.speedscope_host || ENV.fetch(
         "APP_PROFILER_SPEEDSCOPE_URL", "https://speedscope.app"

--- a/lib/app_profiler/server.rb
+++ b/lib/app_profiler/server.rb
@@ -16,6 +16,8 @@ module AppProfiler
     HTTP_CONFLICT = 409
 
     mattr_accessor :enabled, default: false
+    mattr_accessor :cors, default: true
+    mattr_accessor :cors_host, default: "*"
     mattr_accessor :port, default: 0
     mattr_accessor :duration, default: 30
 
@@ -58,7 +60,9 @@ module AppProfiler
             stop_running
             response.status = HTTP_OK
             response.set_header("Content-Type", "application/json")
-            response.set_header("Access-Control-Allow-Origin", "*")
+            if AppProfiler::Server.cors
+              response.set_header("Access-Control-Allow-Origin", AppProfiler::Server.cors_host)
+            end
             profile_hash = profile.to_h
             profile_hash["start_time_nsecs"] = start_time # NOTE: this is not part of the stackprof profile spec
             response.write(JSON.dump(profile_hash))

--- a/lib/app_profiler/server.rb
+++ b/lib/app_profiler/server.rb
@@ -199,6 +199,7 @@ module AppProfiler
         AppProfiler.logger.info(
           "[AppProfiler::Server] listening on addr=#{@transport.socket.addr}"
         )
+        @pid = Process.pid
         at_exit { stop }
       end
 
@@ -252,6 +253,8 @@ module AppProfiler
       end
 
       def stop
+        return unless @pid == Process.pid
+
         @listen_thread.kill
         @transport.stop
       end

--- a/lib/app_profiler/server.rb
+++ b/lib/app_profiler/server.rb
@@ -1,0 +1,197 @@
+# frozen_string_literal: true
+
+require "socket"
+require "rack"
+require "tempfile"
+
+# This module provides a means to start a golang-inspired profile server
+# it is implemented using stdlib and Rack to avoid additional dependencies
+
+module AppProfiler
+  module Server
+    HTTP_OK = 200
+    HTTP_BAD_REQUEST = 400
+    HTTP_NOT_FOUND = 404
+    HTTP_NOT_ALLOWED = 405
+    HTTP_CONFLICT = 409
+    mattr_accessor :port, default: 0
+    mattr_accessor :duration, default: 30
+
+    class ProfileApplication
+      class InvalidProfileArgsError < StandardError; end
+
+      def initialize
+        @semaphore = Thread::Mutex.new
+        @profile_running = false
+      end
+
+      def call(env)
+        handle(Rack::Request.new(env)).finish
+      end
+
+      private
+
+      def handle(request)
+        response = Rack::Response.new
+        if request.request_method != "GET"
+          response.status = HTTP_NOT_ALLOWED
+          response.write("Only GET requests are supported")
+          return response
+        end
+        case request.path
+        when "/profile"
+          begin
+            stackprof_args, duration = validate_profile_params(request.params)
+          rescue => e
+            response.status = HTTP_BAD_REQUEST
+            response.write("Invalid argument #{e.message}")
+            return response
+          end
+
+          if start_running
+            AppProfiler.start(**stackprof_args)
+            sleep(duration)
+            profile = AppProfiler.stop
+            stop_running
+            response.status = HTTP_OK
+            response.set_header("Content-Type", "application/json")
+            response.set_header("Access-Control-Allow-Origin", "*")
+            response.write(JSON.dump(profile.to_h))
+          else
+            response.status = HTTP_CONFLICT
+            response.write("A profile is already running")
+          end
+        else
+          response.status = HTTP_NOT_FOUND
+          response.write("Unsupported endpoint #{request.path}")
+        end
+        response
+      end
+
+      def validate_profile_params(params)
+        params = params.symbolize_keys
+        stackprof_args = {}
+        duration = Float(params.key?(:duration) ? params[:duration] : AppProfiler::Server.duration)
+        if params.key?(:mode)
+          if ["cpu", "wall", "object"].include?(params[:mode])
+            stackprof_args[:mode] = params[:mode].to_sym
+          else
+            raise InvalidProfileArgsError, "invalid mode #{params[:mode]}"
+          end
+        end
+        if params.key?(:interval)
+          stackprof_args[:interval] = params[:interval].to_i
+          raise InvalidProfileArgsError, "invalid interval #{params[:interval]}" if stackprof_args[:interval] <= 0
+        end
+        [stackprof_args, duration]
+      end
+
+      # Prevent multiple concurrent profiles by synchronizing between threads
+      def start_running
+        @semaphore.synchronize do
+          return false if @profile_running
+
+          @profile_running = true
+        end
+      end
+
+      def stop_running
+        @semaphore.synchronize { @profile_running = false }
+      end
+    end
+
+    # This is a minimal, non-compliant "HTTP" server.
+    # It will create an extremely minimal rack environment hash and hand it off
+    # to our application to process
+    class ProfileServer
+      PORT_TEMPFILE_PATH = "/tmp/app_profiler" # for tempfile that indicates port in filename
+      SERVER_ADDRESS = "127.0.0.1" # it is ONLY safe to run this bound to localhost
+
+      attr_reader :port
+
+      def initialize(port = 0)
+        FileUtils.mkdir_p(PORT_TEMPFILE_PATH)
+        @server = TCPServer.new(SERVER_ADDRESS, port)
+        @listen_thread = nil
+        @port = @server.addr[1]
+        @port_file = Tempfile.new("profileserver-#{Process.pid}-port-#{@port}-", PORT_TEMPFILE_PATH)
+        AppProfiler.logger.info(
+          "[AppProfiler::Server] listening on port=#{@port}"
+        )
+      end
+
+      def serve
+        return unless @listen_thread.nil?
+
+        app = ProfileApplication.new
+
+        @listen_thread = Thread.new do
+          loop do
+            Thread.new(@server.accept) do |session|
+              request = session.gets
+              if request.nil?
+                session.close
+                next
+              end
+              method, path, http_version = request.split(" ")
+              path_info, query_string = path.split("?")
+              env = { # an extremely minimal rack env hash, just enough to get the job done
+                "HTTP_VERSION" => http_version,
+                "REQUEST_METHOD" => method,
+                "PATH_INFO" => path_info,
+                "QUERY_STRING" => query_string,
+                "rack.input" => "",
+              }
+              status, headers, body = app.call(env)
+
+              begin
+                session.print("#{http_version} #{status}\r\n")
+                headers.each do |header, value|
+                  session.print("#{header}: #{value}\r\n")
+                end
+                session.print("\r\n")
+                body.each do |part|
+                  session.print(part)
+                end
+              rescue => e
+                AppProfiler.logger.error(
+                  "[AppProfiler::Server] exception #{e} responding to request #{request}: #{e.message}"
+                )
+              ensure
+                session.close
+              end
+            end
+          end
+        end
+      end
+
+      def stop
+        @listen_thread.kill
+        @port_file.unlink
+        @server.close
+      end
+    end
+
+    class << self
+      def start!
+        return unless @server.nil?
+
+        @server = ProfileServer.new(AppProfiler::Server.port)
+        @server.serve
+      end
+
+      def stop!
+        return if @server.nil?
+
+        @server.stop
+        @server = nil
+      end
+
+      def port?
+        return if @server.nil?
+
+        @server.port
+      end
+    end
+  end
+end

--- a/lib/app_profiler/server.rb
+++ b/lib/app_profiler/server.rb
@@ -51,6 +51,7 @@ module AppProfiler
           end
 
           if start_running
+            start_time = Process.clock_gettime(Process::CLOCK_REALTIME, :nanosecond)
             AppProfiler.start(**stackprof_args)
             sleep(duration)
             profile = AppProfiler.stop
@@ -58,7 +59,9 @@ module AppProfiler
             response.status = HTTP_OK
             response.set_header("Content-Type", "application/json")
             response.set_header("Access-Control-Allow-Origin", "*")
-            response.write(JSON.dump(profile.to_h))
+            profile_hash = profile.to_h
+            profile_hash["start_time_nsecs"] = start_time # NOTE: this is not part of the stackprof profile spec
+            response.write(JSON.dump(profile_hash))
           else
             response.status = HTTP_CONFLICT
             response.write("A profile is already running")

--- a/lib/app_profiler/server.rb
+++ b/lib/app_profiler/server.rb
@@ -14,6 +14,8 @@ module AppProfiler
     HTTP_NOT_FOUND = 404
     HTTP_NOT_ALLOWED = 405
     HTTP_CONFLICT = 409
+
+    mattr_accessor :enabled, default: false
     mattr_accessor :port, default: 0
     mattr_accessor :duration, default: 30
 

--- a/test/app_profiler/profile_server_test.rb
+++ b/test/app_profiler/profile_server_test.rb
@@ -7,10 +7,21 @@ module AppProfiler
   module Server
     TEST_PORT = 11337
 
+    class ServerTest < TestCase
+      test ".reset! sets module variables back to their default" do
+        refute_equal(TRANSPORT_TCP, Server.transport)
+        Server.transport = TRANSPORT_TCP
+        refute_equal(DEFAULTS[:transport], Server.transport)
+        Server.reset!
+        refute_equal(TRANSPORT_TCP, Server.transport)
+        assert_equal(DEFAULTS[:transport], Server.transport)
+      end
+    end
+
     class TCPServerTest < TestCase
       def setup
-        AppProfiler::Server.port = 0
-        AppProfiler::Server.transport = TRANSPORT_TCP
+        Server.reset!
+        Server.transport = TRANSPORT_TCP
       end
 
       test ".start! creates a profile server listening on defined port" do
@@ -45,7 +56,8 @@ module AppProfiler
 
     class UNIXServerTest < TestCase
       def setup
-        AppProfiler::Server.transport = TRANSPORT_UNIX
+        Server.reset!
+        Server.transport = TRANSPORT_UNIX
       end
 
       test ".start! creates a profile server listening on unix socket" do
@@ -69,6 +81,10 @@ module AppProfiler
     end
 
     class ProfileServerTest < TestCase
+      def setup
+        Server.reset!
+      end
+
       test ".serve starts a TCP server listening on a socket" do
         with_all_transport_types do |server|
           server.serve
@@ -168,9 +184,7 @@ module AppProfiler
       include Rack::Test::Methods
 
       def setup
-        Server.port = 0
-        Server.cors = true
-        Server.cors_host = "*"
+        Server.reset!
       end
 
       def app

--- a/test/app_profiler/profile_server_test.rb
+++ b/test/app_profiler/profile_server_test.rb
@@ -1,0 +1,215 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "net/http"
+
+module AppProfiler
+  module Server
+    TEST_PORT = 11337
+    class ServerTest < TestCase
+      test ".start! creates a profile server listening on defined port" do
+        AppProfiler.logger.expects(:info).with { |value| value =~ /listening on port=#{TEST_PORT}/ }
+        AppProfiler::Server.port = TEST_PORT
+        assert_not_nil(AppProfiler::Server.start!)
+        assert_not_nil(TCPSocket.new("127.0.0.1", TEST_PORT))
+      ensure
+        assert_nil(AppProfiler::Server.stop!)
+      end
+
+      test ".start! creates a profile server on random free port with undefined port" do
+        AppProfiler.logger.expects(:info).with { |value| value =~ /listening on port/ }
+        AppProfiler::Server.port = 0
+        assert_not_nil(AppProfiler::Server.start!)
+        assert_not_nil(TCPSocket.new("127.0.0.1", AppProfiler::Server.port?))
+      ensure
+        assert_nil(AppProfiler::Server.stop!)
+      end
+
+      test ".stop! stops running profile server" do
+        AppProfiler.logger.expects(:info).with { |value| value =~ /listening on port=#{TEST_PORT}/ }
+        AppProfiler::Server.port = TEST_PORT
+        assert_not_nil(AppProfiler::Server.start!)
+        assert_not_nil(TCPSocket.new("127.0.0.1", TEST_PORT))
+        assert_nil(AppProfiler::Server.stop!)
+        assert_raises(Errno::ECONNREFUSED) { TCPSocket.new("127.0.0.1", TEST_PORT) }
+      ensure
+        assert_nil(AppProfiler::Server.stop!)
+      end
+
+      test ".port? returns the server port" do
+        AppProfiler.logger.expects(:info).with { |value| value =~ /listening on port=#{TEST_PORT}/ }
+        AppProfiler::Server.port = TEST_PORT
+        assert_not_nil(AppProfiler::Server.start!)
+        assert_equal(TEST_PORT, AppProfiler::Server.port?)
+      ensure
+        assert_nil(AppProfiler::Server.stop!)
+      end
+    end
+
+    class ProfileServerTest < TestCase
+      test ".serve serves profile server" do
+        with_test_server(false) do |server|
+          server.serve
+          assert_not_nil(TCPSocket.new("127.0.0.1", server.port))
+        end
+      end
+
+      test ".serve creates tempfile with port" do
+        with_test_server(false) do |server|
+          server.serve
+          port_files = Dir["#{AppProfiler::Server::ProfileServer::PORT_TEMPFILE_PATH}/profileserver-#{Process.pid}-*"]
+          assert_equal(1, port_files.size)
+          port_file = port_files.first
+          matches = port_file.match(/port-(\d+)-/)
+          assert_equal(2, matches.size)
+          assert_equal(server.port, matches[1].to_i)
+        end
+      end
+
+      test ".stop stops profile server" do
+        with_test_server do |server|
+          assert_nil(server.stop)
+          assert_raises(Errno::ECONNREFUSED) { TCPSocket.new("127.0.0.1", server.port) }
+        end
+      end
+
+      test ".port returns the server port" do
+        with_test_server(true, TEST_PORT) do |server|
+          assert_equal(TEST_PORT, server.port)
+        end
+      end
+
+      private
+
+      def with_test_server(start = true, port = 0, &block)
+        AppProfiler.logger.expects(:info).with { |value| value =~ /listening on port/ }
+        server = AppProfiler::Server::ProfileServer.new(port)
+        if start
+          server.serve
+        end
+        yield server
+      ensure
+        assert_nil(server.stop)
+      end
+    end
+
+    class ProfileApplicationTest < TestCase
+      include Rack::Test::Methods
+
+      def app
+        AppProfiler::Server::ProfileApplication.new
+      end
+
+      test "app responds with 405 to unsupported method" do
+        post("/profile?duration=1")
+        assert_equal(decode_status(last_response.status), Net::HTTPMethodNotAllowed)
+      end
+
+      test "app responds with 404 to unknown path" do
+        get("/bad_endpoint")
+        assert_equal(decode_status(last_response.status), Net::HTTPNotFound)
+      end
+
+      test "app responds with 400 with invalid duration" do
+        get("/profile?duration=foo")
+        assert_equal(decode_status(last_response.status), Net::HTTPBadRequest)
+      end
+
+      test "app responds with 400 with invalid mode" do
+        get("/profile?mode=unsupported_mode")
+        assert_equal(decode_status(last_response.status), Net::HTTPBadRequest)
+      end
+
+      test "app responds with 400 with invalid interval" do
+        get("/profile?interval=0")
+        assert_equal(decode_status(last_response.status), Net::HTTPBadRequest)
+      end
+
+      test "app returns valid JSON" do
+        get("/profile?duration=0.01")
+        assert(last_response.ok?)
+        JSON.parse(last_response.body)
+        assert_equal(last_response.get_header("Content-Type"), "application/json")
+      end
+
+      test "app allows CORS" do
+        get("/profile?duration=0.01")
+        assert(last_response.ok?)
+        assert(last_response.has_header?("Access-Control-Allow-Origin"))
+        assert_equal(last_response.get_header("Access-Control-Allow-Origin"), "*")
+      end
+
+      test "app runs a profile for the correct interval" do
+        get("/profile?duration=0.01&interval=1000")
+        assert(last_response.ok?)
+        profile = JSON.parse(last_response.body)
+        assert_equal(1000, profile["interval"])
+      end
+
+      test "app responds with valid profile to /profile defaulting to cpu mode" do
+        with_profiled_workload(proc { loop {} }) do
+          get("/profile?duration=0.1")
+        end
+        assert(last_response.ok?)
+        profile = JSON.parse(last_response.body)
+        assert_equal(profile["mode"], "cpu")
+        assert_operator profile["samples"], :>, 0
+      end
+
+      test "app responds with valid profile wall profile to /profile" do
+        with_profiled_workload(proc { loop { sleep(0.001) } }) do
+          get("/profile?duration=0.1&mode=wall")
+        end
+        assert(last_response.ok?)
+        profile = JSON.parse(last_response.body)
+        assert_equal(profile["mode"], "wall")
+        assert_operator(profile["samples"], :>, 0)
+      end
+
+      test "app responds with valid object profile to /profile" do
+        workload = proc do
+          loop do
+            _ = {}
+            sleep(0.01)
+          end
+        end
+
+        with_profiled_workload(workload) do
+          get("/profile?duration=0.1&mode=object")
+        end
+
+        assert(last_response.ok?)
+        profile = JSON.parse(last_response.body)
+        assert_equal(profile["mode"], "object")
+        assert_operator(profile["samples"], :>, 0)
+      end
+
+      test "app responds with conflict if profile already running" do
+        req = Thread.new do
+          get("/profile?duration=0.2")
+          assert(last_response.ok?)
+        end
+
+        sleep(0.01)
+        get("/profile?duration=0.1")
+        assert_equal(decode_status(last_response.status), Net::HTTPConflict)
+        req.join
+      end
+
+      private
+
+      def with_profiled_workload(workload, &block)
+        work = Thread.new do
+          workload.call
+        end
+        yield
+      ensure
+        work.kill
+      end
+
+      def decode_status(status)
+        Net::HTTPResponse::CODE_TO_OBJ[status.to_s]
+      end
+    end
+  end
+end

--- a/test/app_profiler/profile_server_test.rb
+++ b/test/app_profiler/profile_server_test.rb
@@ -132,6 +132,13 @@ module AppProfiler
         assert_equal(last_response.get_header("Content-Type"), "application/json")
       end
 
+      test "app returns JSON with extra start time" do
+        get("/profile?duration=0.01")
+        assert(last_response.ok?)
+        profile = JSON.parse(last_response.body)
+        assert(profile.key?("start_time_nsecs"))
+      end
+
       test "app allows CORS" do
         get("/profile?duration=0.01")
         assert(last_response.ok?)


### PR DESCRIPTION
# TL;DR

This implements a basic, not fully compliant HTTP server, which hosts a minimal rack app that responds to a single endpoint, `/profile`.

This is heavily inspired by [golang's builtin pprof server](https://pkg.go.dev/net/http/pprof), and aims to provide a similar means to passively profiling arbitrary Ruby applications.

# Why

This is implemented to add support for passively collecting profiles from a running application. App profiler already supports profiling individual requests well, but this is intended to profile a whole process, for a specified duration.

In particular, this will be valuable for leveraging stackprof to provide on-CPU and object profiling, which we have no other means to collect easily and passively at the moment.

# Implementation

## Server

A minimal, non-compliant HTTP server is implemented, which does a blocking read on the server socket in a thread, and will process each request in a thread. It is minimal in order to avoid pulling in any additional dependencies, and is built with just the ruby standard library. It is "Rack app compliant-ish". For the intended use here of supporting just a GET request to a single path with some params, this should be sufficient.

The port that it listens on can be specified, but is intended not to be. It is meant to pick a free port, and bind to that so that each process will have a sort of "debug back door" for profiling.

The port will be logged as well as indicated via the name of a tempfile in a specific location, so that it can be easily discovered. This process is documented in the header comment for the file.

This will allow an external process to discover the port to connect to, and then pull ruby profiles of a specified type and duration for the target process by simply making an HTTP request.

Note that for safety / security reasons, it is **must only bind to localhost only**, meaning that it cannot be called be external clients. Otherwise, this could easily be a DOS vector, and information leak. Additionally, in production it is recommended (and defaults) to use a Unix socket, which will **only** work on the localhost.

As it binds on a completely separate socket, this will not be part of any default application router in rails. This also means it will work on any ruby process using app profiler that calls it, including non web server processes like jobs, etc.

The overhead of this server should be essentially nil if it is not called, as it will simply create a socket, and enter a blocking syscall waiting for a request to process. If the application that includes it is a rails app, the railtie will create one instance per process, should the rails app fork, using activesupport's `ForkTracker`.

## Application

The profiling application here is a Rack app. It implements the `/profile` endpoint, and does various error handling to ensure it is only receiving requests it knows how to handle.

It prevents trying to profile while a profile is already running with a semaphore. The semaphore is acquired and checked at the same time, so that other threads using the same class instance cannot initiate profiling if a profile is already running.

The profile mode and duration of the profiling session can both be specified as parameters. If these parameters are invalid, it should return an error to the client.

To profile, it will simply call `AppProfiler.start`, then sleep for the specified duration, then end the profile. This should let it observe what the rest of the VM is doing. The results are then serialized to JSON and returned in the rack response.

### Usage with Speedscope (locally)

CORS is enabled, so you can call the server directly from speedscope provided that you URL encode the address.

For example, with speedscope running locally on :9292, we can have it directly load a profile from the target app using port 57510. The host before URL encoding is: `http://127.0.0.1:57510/profile?duration=1`, and this can be specified to #profileURL so that speedscope will initiate the profiling session by entering `http://127.0.0.1:9292/#profileURL=http%3A%2F%2F127.0.0.1%3A57510%2Fprofile%3Fduration%3D1` in the URL bar.

# Configuration

This can be configured via a railtie. **It defaults to disabled for now**.

Adding the following to the development/production.rb:

```
config.app_profiler.server_enabled = true
```

Results in it being enabled. Readme documents additional config options.
