### PR TITLE
Use default formatter when profile_url_formatter is nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-[Unreleased]: https://github.com/Shopify/app_profiler
+- Bug fix: Ensure default profile_url_formatter default url formatter is set during initialization (#54)
 
 ## [0.1.1] - 2022-06-15
 

--- a/lib/app_profiler.rb
+++ b/lib/app_profiler.rb
@@ -4,7 +4,6 @@ require "active_support/core_ext/class"
 require "active_support/core_ext/module"
 require "logger"
 require "app_profiler/version"
-require "app_profiler/railtie" if defined?(Rails::Railtie)
 
 module AppProfiler
   class ConfigurationError < StandardError
@@ -81,7 +80,11 @@ module AppProfiler
     end
 
     def profile_url(upload)
+      return unless AppProfiler.profile_url_formatter
+
       AppProfiler.profile_url_formatter.call(upload)
     end
   end
+
+  require "app_profiler/railtie" if defined?(Rails::Railtie)
 end

--- a/lib/app_profiler/middleware/upload_action.rb
+++ b/lib/app_profiler/middleware/upload_action.rb
@@ -27,8 +27,9 @@ module AppProfiler
           return unless autoredirect
 
           # Automatically redirect to profile if autoredirect is true.
-          if response[0].to_i < 500
-            response[1]["Location"] = AppProfiler.profile_url(upload)
+          location = AppProfiler.profile_url(upload)
+          if response[0].to_i < 500 && location
+            response[1]["Location"] = location
             response[0] = 303
           end
         end

--- a/lib/app_profiler/railtie.rb
+++ b/lib/app_profiler/railtie.rb
@@ -5,6 +5,7 @@ require "rails"
 module AppProfiler
   class Railtie < Rails::Railtie
     config.app_profiler = ActiveSupport::OrderedOptions.new
+    config.app_profiler.profile_url_formatter = DefaultProfileFormatter
 
     initializer "app_profiler.configs" do |app|
       AppProfiler.logger = app.config.app_profiler.logger || Rails.logger

--- a/test/app_profiler/middleware/upload_action_test.rb
+++ b/test/app_profiler/middleware/upload_action_test.rb
@@ -71,6 +71,16 @@ module AppProfiler
         assert_equal("https://foo.com/prefix/#{@profile.file.basename}", @response[1]["Location"])
       end
 
+      test ".call does not redirect if the default formatter is nil" do
+        with_autoredirect do
+          with_url_formatter(nil) do
+            UploadAction.call(@profile, response: @response)
+          end
+        end
+
+        refute_predicate(@response[1]["Location"], :present?)
+      end
+
       private
 
       def with_autoredirect


### PR DESCRIPTION
I'm not sure why we have a nil formatter coming in from shopify but regardless we should handle the case when it's `nil`. This change makes it more similar to the original code that uses the default formatter when it's nil.

I've tested this revision in shopify/shopify and the tests are passing.

Questions:
Should I bump the version as part of this PR?

see: https://github.com/Shopify/app_profiler/issues/52 