### PR TITLE
Update profile server to respond with a conflict if already profiling

### DIFF
--- a/lib/app_profiler/server.rb
+++ b/lib/app_profiler/server.rb
@@ -67,25 +67,32 @@ module AppProfiler
 
           if start_running
             start_time = Process.clock_gettime(Process::CLOCK_REALTIME, :nanosecond)
-            AppProfiler.start(**stackprof_args)
-            sleep(duration)
-            profile = AppProfiler.stop
-            stop_running
-            response.status = HTTP_OK
-            response.set_header("Content-Type", "application/json")
+            if AppProfiler.start(**stackprof_args)
+              sleep(duration)
+              profile = AppProfiler.stop
+              stop_running
+              response.status = HTTP_OK
+              response.set_header("Content-Type", "application/json")
+              profile_hash = profile.to_h
+              profile_hash["start_time_nsecs"] = start_time # NOTE: this is not part of the stackprof profile spec
+              response.write(JSON.dump(profile_hash))
+            else
+              response.status = HTTP_CONFLICT
+              response.write("A profile is already running")
+              return response
+            end
             if AppProfiler::Server.cors
               response.set_header("Access-Control-Allow-Origin", AppProfiler::Server.cors_host)
             end
-            profile_hash = profile.to_h
-            profile_hash["start_time_nsecs"] = start_time # NOTE: this is not part of the stackprof profile spec
-            response.write(JSON.dump(profile_hash))
           else
             response.status = HTTP_CONFLICT
             response.write("A profile is already running")
+            return response
           end
         else
           response.status = HTTP_NOT_FOUND
           response.write("Unsupported endpoint #{request.path}")
+          return response
         end
         response
       end

--- a/test/app_profiler/profile_server_test.rb
+++ b/test/app_profiler/profile_server_test.rb
@@ -116,10 +116,10 @@ module AppProfiler
           lines = response.lines
           assert(lines.shift.match?(/HTTP.*200/))
           assert_equal("Content-Type: application/json\r\n", lines.shift)
-          assert_equal("Access-Control-Allow-Origin: *\r\n", lines.shift)
           length_line = lines.shift
           assert(length_line =~ (/Content-Length: (.*)/))
           content_length = Regexp.last_match(1).to_i
+          assert_equal("Access-Control-Allow-Origin: *\r\n", lines.shift)
           assert_equal("\r\n", lines.shift)
           body = lines.shift
           assert_equal(content_length, body.size)
@@ -302,6 +302,14 @@ module AppProfiler
         get("/profile?duration=0.1")
         assert_equal(decode_status(last_response.status), Net::HTTPConflict)
         req.join
+      end
+
+      test "app responds with conflict if stackprof already running" do
+        AppProfiler.start
+        get("/profile?duration=0.1")
+        assert_equal(decode_status(last_response.status), Net::HTTPConflict)
+      ensure
+        AppProfiler.stop
       end
 
       private


### PR DESCRIPTION
It is possible that a per-request profile could coincide with a request to
profile in the background via the profile server. This edge case is currently
unhandled, as we don't check the return code of `AppProfiler.start`.

This adds coverage for this edge case, so that it will respond with an HTTP
conflict, as there is already a profile being taken.