### PR TITLE
Require only needed core extensions and 'json' for server

### DIFF
--- a/lib/app_profiler/server.rb
+++ b/lib/app_profiler/server.rb
@@ -3,7 +3,9 @@
 require "socket"
 require "rack"
 require "tempfile"
-require "active_support/core_ext"
+require "json"
+require "active_support/core_ext/hash"
+require "active_support/core_ext/module"
 
 # This module provides a means to start a golang-inspired profile server
 # it is implemented using stdlib and Rack to avoid additional dependencies


### PR DESCRIPTION
Per your comment https://github.com/Shopify/app_profiler/pull/59/files#r947059314 @rafaelfranca 

I figured I would fix forward rather than revert if that's ok.

I tested with a minimal ruby script and these seem to be the only required extensions. We had also missed requiring `json`, so I added that explicitly as well.