### PR TITLE
Railtie is optional dependency

### DIFF
--- a/app_profiler.gemspec
+++ b/app_profiler.gemspec
@@ -28,7 +28,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency("activesupport", ">= 5.2")
   spec.add_dependency("rack")
-  spec.add_dependency("railties", ">= 5.2")
   spec.add_dependency("stackprof", "~> 0.2")
 
   spec.add_development_dependency("bundler")


### PR DESCRIPTION
In a PR like https://github.com/Shopify/storefront-renderer/pull/15043 when you make `app_profiler` a dependency of a non-Rails app, it would still bring `railties` as a dependency. But that's not necessary and we could make Railtie an optional dependency just for Rails apps.