### PR TITLE
Take logger as an arg in server start method

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,6 @@ PATH
     app_profiler (0.1.2)
       activesupport (>= 5.2)
       rack
-      railties (>= 5.2)
       stackprof (~> 0.2)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -140,10 +140,10 @@ If using as a railtie, only a single option needs to be set:
 config.app_profiler.server_enabled = true
 ```
 
-Alternatively, the server can be directly started with:
+Alternatively, the server can be directly started by passing in a logger as follows:
 
 ```
-AppProfiler::Server.start
+AppProfiler::Server.start(logger)
 ```
 
 The default duration (in seconds), for requests without a duration parameter, can also be

--- a/lib/app_profiler/railtie.rb
+++ b/lib/app_profiler/railtie.rb
@@ -46,9 +46,9 @@ module AppProfiler
 
     initializer "app_profiler.enable_server" do
       if AppProfiler.server.enabled
-        AppProfiler::Server.start
+        AppProfiler::Server.start(AppProfiler.logger)
         ActiveSupport::ForkTracker.after_fork do
-          AppProfiler::Server.start
+          AppProfiler::Server.start(AppProfiler.logger)
         end
       end
     end

--- a/lib/app_profiler/server.rb
+++ b/lib/app_profiler/server.rb
@@ -230,7 +230,8 @@ module AppProfiler
         end
       end
 
-      def initialize(transport)
+      def initialize(transport, logger)
+        @logger = logger
         case transport
         when TRANSPORT_UNIX
           @transport = ProfileServer::UNIX.new
@@ -242,7 +243,7 @@ module AppProfiler
 
         @listen_thread = nil
 
-        AppProfiler.logger.info(
+        @logger.info(
           "[AppProfiler::Server] listening on addr=#{@transport.socket.addr}"
         )
         @pid = Process.pid
@@ -293,7 +294,7 @@ module AppProfiler
                   session.print(part)
                 end
               rescue => e
-                AppProfiler.logger.error(
+                @logger.error(
                   "[AppProfiler::Server] exception #{e} responding to request #{request}: #{e.message}"
                 )
               ensure
@@ -323,10 +324,10 @@ module AppProfiler
         end
       end
 
-      def start
+      def start(logger = Logger.new(IO::NULL))
         return if profile_server
 
-        profile_servers[Process.pid] = ProfileServer.new(AppProfiler::Server.transport)
+        profile_servers[Process.pid] = ProfileServer.new(AppProfiler::Server.transport, logger)
         profile_server.serve
         profile_server
       end


### PR DESCRIPTION
Currently `AppProfiler::Server` is using `AppProfiler.logger` which refers `Rails`. This runs into Sorbet issues for apps that are not Rails based (internally, SFR).

After discussing it with @dalehamel and @kirs -- we are taking logger as an arg for the `AppProfiler::Server#start` method. 

Since this is a breaking change, we have added `null` logger as the default, so at least it does not break existing clients. For apps that are using Rails, we are setting up this correctly in `Railtie`. For a small amount of users we will lose logs, if they do not pass it in. I think this is a reasonable compromise.

CC: @ahayworth 