### PR TITLE
Allow out-of-band, async upload functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Profiling can be triggered in one of two ways:
    - `X-Profile` header format: `[<key>=<value>];...`
 
 
+If `async` query string is provided, then the profile will be uploaded later, in an async manner. One use case for this is when we want to profile a certain % of traffic without incurring costs of inline profile uploads.
+
 You can configure the profile header using:
 
 ```ruby
@@ -49,6 +51,7 @@ Rails.application.config.app_profiler.profile_header = "X-Profile"
 | Key | Value | Notes |
 | --- | ----- | ----- |
 | profile/mode | Supported profiling modes: `cpu`, `wall`, `object`. | Use `profile` in (1), and `mode` in (2). |
+| async | Upload profile in a background thread. When this is set, profile redirect headers are not present in the response.
 | interval | Sampling interval in microseconds. | |
 | ignore_gc | Ignore garbage collection frames | |
 | autoredirect | Redirect request automatically to Speedscope's page after profiling. | |

--- a/lib/app_profiler.rb
+++ b/lib/app_profiler.rb
@@ -39,6 +39,7 @@ module AppProfiler
   mattr_accessor :speedscope_host, default: "https://speedscope.app"
   mattr_accessor :autoredirect, default: false
   mattr_reader   :profile_header, default: "X-Profile"
+  mattr_accessor :profile_async_header, default: "X-Profile-Async"
   mattr_accessor :context, default: nil
   mattr_reader   :profile_url_formatter,
     default: DefaultProfileFormatter
@@ -47,6 +48,8 @@ module AppProfiler
   mattr_accessor :viewer, default: Viewer::SpeedscopeViewer
   mattr_accessor :middleware, default: Middleware
   mattr_accessor :server, default: Server
+  mattr_accessor :upload_queue_max_length, default: 10
+  mattr_accessor :upload_queue_interval_secs, default: 5
 
   class << self
     def run(*args, &block)

--- a/lib/app_profiler/middleware.rb
+++ b/lib/app_profiler/middleware.rb
@@ -41,6 +41,7 @@ module AppProfiler
         profile,
         response: response,
         autoredirect: params.autoredirect,
+        async: params.async
       )
 
       response

--- a/lib/app_profiler/middleware/upload_action.rb
+++ b/lib/app_profiler/middleware/upload_action.rb
@@ -4,16 +4,19 @@ module AppProfiler
   class Middleware
     class UploadAction < BaseAction
       class << self
-        def call(profile, response: nil, autoredirect: nil)
-          profile_upload = profile.upload
+        def call(profile, response: nil, autoredirect: nil, async: false)
+          if async
+            profile.enqueue_upload
+            response[1][AppProfiler.profile_async_header] = true
+          else
+            profile_upload = profile.upload
 
-          return unless response
-
-          append_headers(
-            response,
-            upload: profile_upload,
-            autoredirect: autoredirect.nil? ? AppProfiler.autoredirect : autoredirect
-          )
+            append_headers(
+              response,
+              upload: profile_upload,
+              autoredirect: autoredirect.nil? ? AppProfiler.autoredirect : autoredirect
+            ) if response
+          end
         end
 
         private

--- a/lib/app_profiler/parameters.rb
+++ b/lib/app_profiler/parameters.rb
@@ -8,14 +8,15 @@ module AppProfiler
     MIN_INTERVALS = { "cpu" => 200, "wall" => 200, "object" => 400 }.freeze
     MODES = DEFAULT_INTERVALS.keys.freeze
 
-    attr_reader :autoredirect
+    attr_reader :autoredirect, :async
 
-    def initialize(mode: :wall, interval: nil, ignore_gc: false, autoredirect: false, metadata: {})
+    def initialize(mode: :wall, interval: nil, ignore_gc: false, autoredirect: false, async: false, metadata: {})
       @mode = mode.to_sym
       @interval = [interval&.to_i || DEFAULT_INTERVALS.fetch(@mode.to_s), MIN_INTERVALS.fetch(@mode.to_s)].max
       @ignore_gc = !!ignore_gc
       @autoredirect = autoredirect
       @metadata = { context: AppProfiler.context }.merge(metadata)
+      @async = async
     end
 
     def valid?

--- a/lib/app_profiler/profile.rb
+++ b/lib/app_profiler/profile.rb
@@ -56,6 +56,10 @@ module AppProfiler
       nil
     end
 
+    def enqueue_upload
+      AppProfiler.storage.enqueue_upload(self)
+    end
+
     def file
       @file ||= path.tap do |p|
         p.dirname.mkpath

--- a/lib/app_profiler/railtie.rb
+++ b/lib/app_profiler/railtie.rb
@@ -28,11 +28,14 @@ module AppProfiler
         "APP_PROFILER_SPEEDSCOPE_URL", "https://speedscope.app"
       )
       AppProfiler.profile_header = app.config.app_profiler.profile_header || "X-Profile"
+      AppProfiler.profile_async_header = app.config.app_profiler.profile_async_header || "X-Profile-Async"
       AppProfiler.profile_root = app.config.app_profiler.profile_root || Rails.root.join(
         "tmp", "app_profiler"
       )
       AppProfiler.context = app.config.app_profiler.context || Rails.env
       AppProfiler.profile_url_formatter = app.config.app_profiler.profile_url_formatter
+      AppProfiler.upload_queue_max_length = app.config.app_profiler.upload_queue_max_length || 10
+      AppProfiler.upload_queue_interval_secs = app.config.app_profiler.upload_queue_interval_secs || 5
     end
 
     initializer "app_profiler.add_middleware" do |app|

--- a/lib/app_profiler/request_parameters.rb
+++ b/lib/app_profiler/request_parameters.rb
@@ -12,6 +12,10 @@ module AppProfiler
       query_param("autoredirect") || profile_header_param("autoredirect")
     end
 
+    def async
+      query_param("async")
+    end
+
     def valid?
       if mode.blank?
         return false

--- a/lib/app_profiler/storage/base_storage.rb
+++ b/lib/app_profiler/storage/base_storage.rb
@@ -9,6 +9,10 @@ module AppProfiler
       def self.upload(_profile)
         raise NotImplementedError
       end
+
+      def self.enqueue_upload(_profile)
+        raise NotImplementedError
+      end
     end
   end
 end

--- a/lib/app_profiler/storage/file_storage.rb
+++ b/lib/app_profiler/storage/file_storage.rb
@@ -21,6 +21,10 @@ module AppProfiler
         def upload(profile)
           Location.new(profile.file)
         end
+
+        def enqueue_upload(profile)
+          upload(profile)
+        end
       end
     end
   end

--- a/test/app_profiler/middleware/upload_action_test.rb
+++ b/test/app_profiler/middleware/upload_action_test.rb
@@ -56,6 +56,8 @@ module AppProfiler
 
         assert_predicate(@response[1][AppProfiler.profile_header], :present?)
         assert_predicate(@response[1][AppProfiler.profile_data_header], :present?)
+        assert_predicate(@response[1][AppProfiler.profile_async_header], :blank?)
+
         assert_predicate(@response[1]["Location"], :present?)
         assert_equal(@response[0], 303)
       end
@@ -79,6 +81,11 @@ module AppProfiler
         end
 
         refute_predicate(@response[1]["Location"], :present?)
+      end
+
+      test ".call with async: true" do
+        UploadAction.call(@profile, response: @response, async: true)
+        assert(@response[1][AppProfiler.profile_async_header])
       end
 
       private

--- a/test/app_profiler/middleware_test.rb
+++ b/test/app_profiler/middleware_test.rb
@@ -289,6 +289,18 @@ module AppProfiler
       end
     end
 
+    test "profiles are not uploaded synchronously when async is requested" do
+      old_storage = AppProfiler.storage
+      AppProfiler.storage = AppProfiler::Storage::GoogleCloudStorage
+      assert_profiles_dumped(0) do
+        middleware = AppProfiler::Middleware.new(app_env)
+        response = middleware.call(mock_request_env(path: "/?profile=cpu&async=true"))
+        assert(response[1]["X-Profile-Async"])
+      end
+    ensure
+      AppProfiler.storage = old_storage
+    end
+
     class CustomMiddleware < AppProfiler::Middleware
       def call(env)
         super(env, AppProfiler::Parameters.new)

--- a/test/app_profiler/parameters_test.rb
+++ b/test/app_profiler/parameters_test.rb
@@ -16,5 +16,10 @@ module AppProfiler
     test "#mode is :wall by default" do
       assert_equal :wall, Parameters.new.to_h.fetch(:mode)
     end
+
+    test "#async is false by default" do
+      assert_not_predicate Parameters.new, :async
+      assert_predicate Parameters.new(async: true), :async
+    end
   end
 end


### PR DESCRIPTION
TL;DR; Adds a new query string param `async`. When specified, profile uploads happen in a background thread. 

One use case for this is when we want to profile a certain % of traffic without end users explicitly requesting it. In such situations uploading profiles inline does not scale.

From the `README`:

>If the `async` key in the query string is set to `1` or `true`, then profile will be uploaded later, in an async manner. One use case for this is when we want to profile a certain % of traffic without incurring costs of inline profile uploads.

If the `async` parameter is specified we add to a queue/buffer -- which we process every `upload_queue_interval_secs`.  The queue is [SizedQueue](https://ruby-doc.org/core-2.5.0/SizedQueue.html). 

CC @jasonhl 

