### PR TITLE
Better support reforking

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -198,4 +198,4 @@ DEPENDENCIES
   rubocop-shopify
 
 BUNDLED WITH
-   2.2.22
+   2.4.18


### PR DESCRIPTION
AppProfiler does support forking already, but it never garbage collect the parent server which could be an issue if we refork a lot.

It also doesn't play very well with Pitchfork IO closing safety mecanism.

This PR improve both.