### PR TITLE
[Flaky test] timezone is nil in thread

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -24,6 +24,7 @@ TMP_ROOT  = TEST_ROOT.join("..").join("tmp")
 TMP_APP_ROOT = TMP_ROOT.join("app")
 
 Time.zone = "Pacific Time (US & Canada)" # For Time.zone.now.
+Time.zone_default = "Pacific Time (US & Canada)"
 
 Mocha.configure do |config|
   config.stubbing_method_unnecessarily = :prevent


### PR DESCRIPTION
After merging #80 -- I got a test failure on main

```
/home/runner/work/app_profiler/app_profiler/lib/app_profiler/profile.rb:78:in `path': undefined method `now' for nil:NilClass (NoMethodError)
	from /home/runner/work/app_profiler/app_profiler/lib/app_profiler/profile.rb:64:in `file'
	from /home/runner/work/app_profiler/app_profiler/lib/app_profiler/storage/file_storage.rb:22:in `upload'
	from /home/runner/work/app_profiler/app_profiler/test/support/mock_storage.rb:15:in `upload'
	from /home/runner/work/app_profiler/app_profiler/lib/app_profiler/profile.rb:41:in `upload'

```

reproduce:

```
require 'active_support/all'

Time.zone = 'EST'
puts "[Main] time zone -- [#{Time.zone}]"

Thread.new do
  puts "[Thread] time zone -- [#{Time.zone}]"
end

sleep 1
```

It appears that `Zone` will be `nil` inside a thread and does not get copied over from main. I am guessing rails falls back to some other value, because I cannot reproduce this inside a basic rails app. 


