### PR TITLE
[Flaky test] terminate background thread

### DIFF
--- a/test/app_profiler/middleware_test.rb
+++ b/test/app_profiler/middleware_test.rb
@@ -298,6 +298,7 @@ module AppProfiler
         assert(response[1]["X-Profile-Async"])
       end
     ensure
+      AppProfiler::Storage::GoogleCloudStorage.reset_queue # kill the background thread and reset the queue
       AppProfiler.storage = old_storage
     end
 


### PR DESCRIPTION
This was a tricky one.

If `AppProfiler::Storage::GoogleCloudStorageTest#test_process_queue_thread_is_alive_after_first_upload` is the first test which runs in `AppProfiler::Storage::GoogleCloudStorageTest` and `AppProfiler::MiddlewareTest#test_profiles_are_not_uploaded_synchronously_when_async_is_requested` ran previously, 
then this will fail:

https://github.com/Shopify/app_profiler/blob/b12fc9527a01566945d1de7d1dba1b942014d253/test/app_profiler/storage/google_cloud_storage_test.rb#L81

Queue and the thread gets reset in `GoogleCloudStorageTest#teardown`, but I forgot to do in `MiddlewareTest`. 