### PR TITLE
Add support custom file prefix block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-- Change `'X-Profile-Async: true` to `'X-Profile-Async: "true"`
+## [0.1.6] - 2023-10-18
+
+- Allow passing custom block to determine profile file name prefix (#94)
+- Change `'X-Profile-Async: true` to `'X-Profile-Async: "true"` (#95)
 
 ## [0.1.5] - 2023-09-25
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    app_profiler (0.1.5)
+    app_profiler (0.1.6)
       activesupport (>= 5.2)
       rack
       stackprof (~> 0.2)

--- a/README.md
+++ b/README.md
@@ -65,6 +65,14 @@ AppProfiler.autoredirect = true
 Rails.application.config.app_profiler.autoredirect = true
 ```
 
+File names of profiles are prefixed by default with timezoned date and time, follow by profile mode, an id, and hostname of the machine where it was capture. For example: `20221006-121110-cpu-613fa8d2cdde5820d5312dea1cfa43d9-macbook-pro-work.lan.json`. To customize the prefix you can provide a proc:
+
+```ruby
+AppProfiler.profile_file_prefix = -> { "custom-prefix" }
+# OR
+Rails.application.config.app_profiler.profile_file_prefix = -> { "custom-prefix" }
+```
+
 To customize the redirect location you can provide a proc:
 
 ```ruby

--- a/lib/app_profiler.rb
+++ b/lib/app_profiler.rb
@@ -13,6 +13,10 @@ module AppProfiler
     "#{AppProfiler.speedscope_host}#profileURL=#{upload.url}"
   end
 
+  DefaultProfilePrefix = proc do
+    Time.zone.now.strftime("%Y%m%d-%H%M%S")
+  end
+
   module Storage
     autoload :BaseStorage, "app_profiler/storage/base_storage"
     autoload :FileStorage, "app_profiler/storage/file_storage"
@@ -50,6 +54,7 @@ module AppProfiler
   mattr_accessor :server, default: Server
   mattr_accessor :upload_queue_max_length, default: 10
   mattr_accessor :upload_queue_interval_secs, default: 5
+  mattr_accessor :profile_file_prefix, default: DefaultProfilePrefix
 
   class << self
     def run(*args, &block)

--- a/lib/app_profiler/profile.rb
+++ b/lib/app_profiler/profile.rb
@@ -75,7 +75,7 @@ module AppProfiler
 
     def path
       filename = [
-        Time.zone.now.strftime("%Y%m%d-%H%M%S"),
+        AppProfiler.profile_file_prefix.call,
         mode,
         id,
         Socket.gethostname,

--- a/lib/app_profiler/railtie.rb
+++ b/lib/app_profiler/railtie.rb
@@ -36,6 +36,7 @@ module AppProfiler
       AppProfiler.profile_url_formatter = app.config.app_profiler.profile_url_formatter
       AppProfiler.upload_queue_max_length = app.config.app_profiler.upload_queue_max_length || 10
       AppProfiler.upload_queue_interval_secs = app.config.app_profiler.upload_queue_interval_secs || 5
+      AppProfiler.profile_file_prefix = app.config.app_profiler.profile_file_prefix || DefaultProfilePrefix
     end
 
     initializer "app_profiler.add_middleware" do |app|

--- a/lib/app_profiler/version.rb
+++ b/lib/app_profiler/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module AppProfiler
-  VERSION = "0.1.5"
+  VERSION = "0.1.6"
 end

--- a/test/app_profiler/profile_test.rb
+++ b/test/app_profiler/profile_test.rb
@@ -144,5 +144,18 @@ module AppProfiler
         profile.file
       end
     end
+
+    test "#file uses custom profile_file_prefix block when provided" do
+      profile = Profile.new(stackprof_profile)
+
+      AppProfiler.stubs(:profile_file_prefix).returns(-> { "want-something-different" })
+      assert_match(/want-something-different-/, File.basename(profile.file.to_s))
+    end
+
+    test "#file uses default prefix format when no custom profile_file_prefix block is provided" do
+      profile = Profile.new(stackprof_profile)
+
+      assert_match(/^#{Time.zone.now.strftime("%Y%m%d")}/, File.basename(profile.file.to_s))
+    end
   end
 end

--- a/test/app_profiler/profile_test.rb
+++ b/test/app_profiler/profile_test.rb
@@ -153,9 +153,10 @@ module AppProfiler
     end
 
     test "#file uses default prefix format when no custom profile_file_prefix block is provided" do
-      profile = Profile.new(stackprof_profile)
-
-      assert_match(/^#{Time.zone.now.strftime("%Y%m%d")}/, File.basename(profile.file.to_s))
+      travel_to Time.zone.local(2022, 10, 06, 12, 11, 10) do
+        profile = Profile.new(stackprof_profile)
+        assert_match(/^20221006-121110/, File.basename(profile.file.to_s))
+      end
     end
   end
 end


### PR DESCRIPTION
Move default file prefix behaviour out into a default block and allow for gem consumers to provide a custom block via `AppProfiler.profile_file_prefix`. 

We need this as internally, we use the file name of exported profiles as last-resort metadata source, and the current behaviour of using timezone time is not machine friendly. 