### PR TITLE
Change X-Profile-Async value to String

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Change `'X-Profile-Async: true` to `'X-Profile-Async: "true"`
+
 ## [0.1.5] - 2023-09-25
 
 - Fix `AppProfiler::Server` to no longer be immortal. This avoid leaking servers when respawning the server after fork (#93)

--- a/lib/app_profiler/middleware/upload_action.rb
+++ b/lib/app_profiler/middleware/upload_action.rb
@@ -7,7 +7,7 @@ module AppProfiler
         def call(profile, response: nil, autoredirect: nil, async: false)
           if async
             profile.enqueue_upload
-            response[1][AppProfiler.profile_async_header] = true
+            response[1][AppProfiler.profile_async_header] = "true"
           else
             profile_upload = profile.upload
 

--- a/test/app_profiler/middleware/upload_action_test.rb
+++ b/test/app_profiler/middleware/upload_action_test.rb
@@ -85,7 +85,7 @@ module AppProfiler
 
       test ".call with async: true" do
         UploadAction.call(@profile, response: @response, async: true)
-        assert(@response[1][AppProfiler.profile_async_header])
+        assert_equal(@response[1][AppProfiler.profile_async_header], "true")
       end
 
       private


### PR DESCRIPTION
Otherwise linter complains:
```
Minitest::UnexpectedError: Rack::Lint::LintError: a header value must be a String, but the value of 'X-Profile-Async' is a TrueClass
```