### PR TITLE
Undefine the Server finalizer when closing

### DIFF
--- a/lib/app_profiler/server.rb
+++ b/lib/app_profiler/server.rb
@@ -225,8 +225,10 @@ module AppProfiler
         end
 
         def stop
-          File.unlink(@socket_file) if File.exist?(@socket_file) && File.socket?(@socket_file)
           @socket.close
+          File.unlink(@socket_file) if File.exist?(@socket_file) && File.socket?(@socket_file)
+          ObjectSpace.undefine_finalizer(self)
+          nil
         end
 
         def abandon


### PR DESCRIPTION
Fix: https://github.com/Shopify/app_profiler/issues/96

Otherwise the finalizer might trigger when another server is active and using that path.

cc @bmansoob some test don't pass on my machine on `main`, but could you try this? I think that would fix it.