### PR TITLE
Use viewing in test mode by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ AppProfiler.storage.credentials = { "key" => "value" }
 Rails.application.config.app_profiler.storage_credentials = { "key" => "value" }
 ```
 
-Note that in `development` mode the file isn't uploaded. Instead, it is viewed via the `Middleware::ViewAction`. If you want to change that, use the `middleware_action` configuration:
+Note that in `development` and `test` modes the file isn't uploaded. Instead, it is viewed via the `Middleware::ViewAction`. If you want to change that, use the `middleware_action` configuration:
 
 ```ruby
 Rails.application.config.app_profiler.middleware_action = AppProfiler::Middleware::UploadAction

--- a/lib/app_profiler/railtie.rb
+++ b/lib/app_profiler/railtie.rb
@@ -63,7 +63,7 @@ module AppProfiler
     private
 
     def default_middleware_action
-      if Rails.env.development?
+      if Rails.env.development? || Rails.env.test?
         Middleware::ViewAction
       else
         Middleware::UploadAction


### PR DESCRIPTION
Uploading in test mode doesn't really make sense, unless you're using CI maybe, but in that case it can be overridden.