### PR TITLE
WIP precompile task for firefox

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,6 +3,8 @@
 require "bundler/gem_tasks"
 require "rake/testtask"
 
+load "lib/tasks/firefox_profiler_compile.rake"
+
 Rake::TestTask.new(:test) do |t|
   t.libs << "test"
   t.libs << "lib"

--- a/lib/app_profiler/yarn/command.rb
+++ b/lib/app_profiler/yarn/command.rb
@@ -7,6 +7,7 @@ module AppProfiler
 
       VALID_COMMANDS = [
         ["which", "yarn"],
+        ["which", "gcloud"],
         ["yarn", "init", "--yes"],
         ["yarn", "add", "speedscope", "--dev", "--ignore-workspace-root-check"],
         ["yarn", "run", "speedscope", /.*\.json/],

--- a/lib/app_profiler/yarn/with_firefox_profiler.rb
+++ b/lib/app_profiler/yarn/with_firefox_profiler.rb
@@ -1,9 +1,16 @@
 # frozen_string_literal: true
 
+require "rubygems/package"
+require "zlib"
+require "open-uri"
+
 module AppProfiler
   module Yarn
     module WithFirefoxProfile
       include Command
+      class CommandError < StandardError; end
+
+      INSTALL_DIRECTORY = "./tmp"
 
       def setup_yarn
         super
@@ -18,12 +25,68 @@ module AppProfiler
         AppProfiler.root.join("node_modules/firefox-profiler/dist").exist?
       end
 
-      def fetch_firefox_profiler
-        raise ArgumentError unless AppProfiler.gecko_viewer_package.start_with?("https://github.com")
+      def github_source?
+        AppProfiler.gecko_viewer_package.start_with?("https://github.com")
+      end
 
+      def compiled_source?
+        AppProfiler.gecko_viewer_package.start_with?("https://") &&
+          AppProfiler.gecko_viewer_package.end_with?("_compiled.tar.gz")
+      end
+
+      def append_auth_header(opts)
+        if AppProfiler.gecko_viewer_package.start_with?("https://storage.googleapis.com/")
+          exec("which", "gcloud", silent: true) do
+            raise(
+              CommandError,
+              <<~MSG.squish
+                `gcloud` command not found, but gcloud auth required.
+                Please install `gcloud` or make it available in PATH.
+              MSG
+            )
+          end
+
+          opts["Authorization"] = "Bearer " + %x(gcloud auth print-access-token)
+        end
+      end
+
+      def fetch_firefox_profiler
+        dir = INSTALL_DIRECTORY
+
+        if github_source?
+          fetch_from_github(dir)
+        elsif compiled_source?
+          fetch_pre_compiled("#{dir}/firefox-profiler")
+        else
+          raise ArgumentError, "#{AppProfiler.gecko_viewer_package} is not a valid source for firefox profiler"
+        end
+
+        yarn("add", "--dev", "#{dir}/firefox-profiler")
+      end
+
+      def fetch_pre_compiled(dir)
+        opts = {}
+        append_auth_header(opts)
+        tar_gz_file = URI.parse(AppProfiler.gecko_viewer_package).open(opts)
+
+        Gem::Package::TarReader.new(Zlib::GzipReader.open(tar_gz_file)) do |tar|
+          tar.each do |entry|
+            next if entry.directory?
+
+            target_file = File.join(dir, entry.full_name)
+
+            FileUtils.mkdir_p(File.dirname(target_file))
+
+            File.open(target_file, "wb") do |f|
+              f.write(entry.read)
+            end
+          end
+        end
+      end
+
+      def fetch_from_github(dir)
         repo, branch = AppProfiler.gecko_viewer_package.to_s.split("#")
 
-        dir = "./tmp"
         FileUtils.mkdir_p(dir)
         Dir.chdir(dir) do
           clone_args = ["git", "clone", repo, "firefox-profiler"]
@@ -41,8 +104,6 @@ module AppProfiler
         yarn("--cwd", "#{dir}/firefox-profiler", "build-prod")
         patch_file("#{dir}/firefox-profiler/dist/index.html", 'href="locales/en-US/app.ftl"',
           'href="/app_profiler/firefox/viewer/locales/en-US/app.ftl"')
-
-        yarn("add", "--dev", "#{dir}/firefox-profiler")
       end
 
       def patch_firefox_profiler(dir)

--- a/lib/tasks/firefox_profiler_compile.rake
+++ b/lib/tasks/firefox_profiler_compile.rake
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "rubygems/package"
+require "zlib"
+require "fileutils"
+
+require "app_profiler"
+require "app_profiler/yarn/command"
+require "app_profiler/yarn/with_firefox_profiler"
+
+# The bundle is already compiled, so we can ignore most of the source contents
+PACKAGE_INCLUDE = [
+  %r{^\.circleci/config\.yml$},
+  %r{^bin/pre-install\.js$},
+  /^package\.json$/,
+  /^dist/,
+].freeze
+
+class CompileShim
+  include AppProfiler::Yarn::WithFirefoxProfile
+end
+
+namespace :firefox_profiler do
+  desc "Compile firefox profiler"
+  task :compile do
+    AppProfiler.root = Pathname.getwd
+    CompileShim.new.setup_yarn
+  end
+  desc "Package firefox profiler"
+  task package: :compile do
+    package_directory("node_modules/firefox-profiler", "out.tar.gz")
+  end
+end
+
+def package_directory(source_dir, output)
+  File.open(output, "wb") do |tar_gz_file|
+    Zlib::GzipWriter.wrap(tar_gz_file) do |gzip_file|
+      Dir.chdir(source_dir) do
+        Gem::Package::TarWriter.new(gzip_file) do |tar|
+          Dir["**/*", ".*/**/*"].each do |file|
+            next unless PACKAGE_INCLUDE.any? { |pattern| file =~ pattern }
+
+            mode = File.stat(file).mode
+
+            if File.directory?(file)
+              tar.mkdir(file, mode)
+            else
+              tar.add_file_simple(file, mode, File.size(file)) do |tar_file|
+                IO.copy_stream(File.open(file, "rb"), tar_file)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds support for fetching firefox profiler from a pre-compiled bundle.

By default, also adds support for fetching from GCS behind auth using gcloud token.

Adds rake tasks as helpers to compile and package the bundle.