### PR TITLE
Let setup-ruby action handle bundler

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,7 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
-    - name: Build
-      run: |
-        gem install bundler
-        bundle install --jobs 4 --retry 3
+        bundler-cache: true
     - name: Test on ${{ matrix.ruby }}
       run: |
         bundle exec rake


### PR DESCRIPTION
It resolves some CI issues with ruby 2.7 ([e.g.](https://github.com/Shopify/app_profiler/actions/runs/8335697996/job/22811641704?pr=114)) and also sets up caching for faster future builds.