### PR TITLE
Remove Autoredirect by Default in Remote Viewer

### DIFF
--- a/lib/app_profiler/viewer/speedscope_remote_viewer.rb
+++ b/lib/app_profiler/viewer/speedscope_remote_viewer.rb
@@ -21,8 +21,12 @@ module AppProfiler
         id = Middleware.id(@profile.file)
 
         if response && response[0].to_i < 500
-          response[1]["Location"] = "/app_profiler/#{id}"
-          response[0] = 303
+          if autoredirect
+            response[0] = 303
+            response[1]["Location"] = "/app_profiler/#{id}"
+          elsif AppProfiler.profile_header
+            response[1][AppProfiler.profile_header] = "/app_profiler/#{id}"
+          end
         else
           AppProfiler.logger.info("[Profiler] Profile available at /app_profiler/#{id}\n")
         end

--- a/test/app_profiler/viewer/speedscope_remote_viewer_test.rb
+++ b/test/app_profiler/viewer/speedscope_remote_viewer_test.rb
@@ -25,14 +25,27 @@ module AppProfiler
         viewer.view
       end
 
-      test "#view with response redirects to URL" do
+      test "#view with response sets the profiler header" do
+        response = [200, {}, ["OK"]]
+        profile = BaseProfile.from_stackprof(stackprof_profile)
+
+        view = SpeedscopeRemoteViewer.new(profile)
+        id = SpeedscopeRemoteViewer::Middleware.id(profile.file)
+
+        view.view(response: response)
+
+        assert_equal(200, response[0])
+        assert_equal("/app_profiler/#{id}", response[1][AppProfiler.profile_header])
+      end
+
+      test "#view with response redirects to URL when autoredirect is set" do
         response = [200, {}, ["OK"]]
         profile = BaseProfile.from_stackprof(stackprof_profile)
 
         viewer = SpeedscopeRemoteViewer.new(profile)
         id = SpeedscopeRemoteViewer::Middleware.id(profile.file)
 
-        viewer.view(response: response)
+        viewer.view(response: response, autoredirect: true)
 
         assert_equal(303, response[0])
         assert_equal("/app_profiler/#{id}", response[1]["Location"])


### PR DESCRIPTION
# Goal

I work on GraphiQL within Services Internal in my spare time and noticed that profiling doesn’t seem to work in dev environments while it does in prod.
I found the root of this is because in Dev the profiler returns an HTTP redirect

Decided to make the auto redirect rely on the `autoredirect` param and to place the link to `AppProfiler.profiler_header` instead. 

---

Open questions:
It seems like this behaviour exists to some an extent in the [UploadAction](https://github.com/Shopify/app_profiler/blob/main/lib/app_profiler/middleware/upload_action.rb) is there any reason why we can't use this instead