### PR TITLE
Enforce ruby version requirement with Gemfile for dependabot

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gemspec
 # Specify the same dependency sources as the application Gemfile
 gem("activesupport", "~> 5.2")
 gem("railties", "~> 5.2")
-gem("vernier", "~> 0.7.0")
+gem("vernier", "~> 0.7.0") if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.2.1")
 
 gem("google-cloud-storage", "~> 1.21")
 gem("rubocop", require: false)


### PR DESCRIPTION
It looks like dependabot tasks run with an ancient Ruby, and it isn't happy with the vernier dependency in the Gemfile.

See: https://github.com/Shopify/app_profiler/actions/runs/9566253375

To work around this, vernier will only be included on versions that actually support it.