### PR TITLE
Forward profile metadata to GCS

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,14 @@ The custom middleware can then be configured like the following:
 Rails.application.config.app_profiler.middleware = AppProfilerAuthorizedMiddleware
 ```
 
+Profile's custom metadata can be passed on to the uploaded [GCS object](https://cloud.google.com/storage/docs/metadata) using:
+
+```ruby
+AppProfiler.forward_metadata_on_upload = true
+# OR
+Rails.application.config.app_profiler.forward_metadata_on_upload = true
+```
+
 ## Profile Server
 
 This option allows for profiles to be passively collected via an HTTP endpoint,

--- a/lib/app_profiler.rb
+++ b/lib/app_profiler.rb
@@ -61,6 +61,7 @@ module AppProfiler
   mattr_reader :profile_enqueue_success, default: nil
   mattr_reader :profile_enqueue_failure, default: nil
   mattr_reader :after_process_queue, default: nil
+  mattr_accessor :forward_metadata_on_upload, default: false
 
   class << self
     def run(*args, backend: nil, **kwargs, &block)

--- a/lib/app_profiler/profile.rb
+++ b/lib/app_profiler/profile.rb
@@ -80,6 +80,10 @@ module AppProfiler
       @data
     end
 
+    def metadata
+      @data[:metadata]
+    end
+
     def mode
       raise NotImplementedError
     end

--- a/lib/app_profiler/railtie.rb
+++ b/lib/app_profiler/railtie.rb
@@ -41,6 +41,7 @@ module AppProfiler
       AppProfiler.profile_enqueue_failure = app.config.app_profiler.profile_enqueue_failure
       AppProfiler.after_process_queue = app.config.app_profiler.after_process_queue
       AppProfiler.backend = app.config.app_profiler.profiler_backend || :stackprof
+      AppProfiler.forward_metadata_on_upload = app.config.app_profiler.forward_metadata_on_upload || false
     end
 
     initializer "app_profiler.add_middleware" do |app|

--- a/lib/app_profiler/storage/google_cloud_storage.rb
+++ b/lib/app_profiler/storage/google_cloud_storage.rb
@@ -15,6 +15,10 @@ module AppProfiler
         def upload(profile, _params = {})
           file = profile.file.open
 
+          metadata = if AppProfiler.forward_metadata_on_upload && profile.metadata.present?
+            profile.metadata
+          end
+
           ActiveSupport::Notifications.instrument(
             "gcs_upload.app_profiler",
             file_size: file.size,
@@ -24,6 +28,7 @@ module AppProfiler
               gcs_filename(profile),
               content_type: "application/json",
               content_encoding: "gzip",
+              metadata: metadata,
             )
           ensure
             profile.file.unlink


### PR DESCRIPTION
This will help in downstream ingestion processes where there is a need to extract profiles' metadata and do something with it, without having to deserialise the actual profile. 

We have such a use-case; we use values in metadata as filters in Observe.

