### PR TITLE
Sampler - fix probability logic

### DIFF
--- a/lib/app_profiler/sampler.rb
+++ b/lib/app_profiler/sampler.rb
@@ -5,16 +5,15 @@ module AppProfiler
   module Sampler
     class << self
       def profile_params(request, config)
-        random = Kernel.rand
-        return unless sample?(random, config, request)
+        return unless sample?(config, request)
 
-        get_profile_params(config, random)
+        get_profile_params(config)
       end
 
       private
 
-      def sample?(random, config, request)
-        return false if random > config.sample_rate
+      def sample?(config, request)
+        return false if Kernel.rand > config.sample_rate
 
         path = request.path
         return false unless config.paths.any? { |p| path.match?(p) }
@@ -22,11 +21,11 @@ module AppProfiler
         true
       end
 
-      def get_profile_params(config, random)
-        backend_name = select_random(config.backends_probability, random)
+      def get_profile_params(config)
+        backend_name = select_random(config.backends_probability, Kernel.rand)
         backend_config = config.get_backend_config(backend_name)
 
-        mode = select_random(backend_config.modes_probability, random)
+        mode = select_random(backend_config.modes_probability, Kernel.rand)
         interval = backend_config.interval_for(mode)
 
         AppProfiler::Parameters.new(


### PR DESCRIPTION
There was a bug in how `Kernel.rand` got passed to every function.

One of the first things we check:

`return false if random > config.sample_rate`

If the `sample_rate` is something like 0.001 then only lower probabilities options (mode, backend) will be chosen (because random was created once and passed down).

Fixed it by calling Kernel.rand every time.

