### PR TITLE
[Sampler] Allow passing in a Proc to enable/disable the sampler.

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,13 +341,20 @@ By default, the stackprof backend will be used.
 
 The `AppProfiler` middleware can be configured to sample a percentage of requests for profiling. This can be useful for profiling a subset of requests in production without profiling every request.
 
-To enable profile sampling:
+To enable profile sampling, you can either set `profile_sampler_enabled` to `true` or provide your own custom `Proc`:
 
 ```ruby
 AppProfiler.profile_sampler_enabled = true
 # OR
 Rails.application.config.app_profiler.profile_sampler_enabled = true
 ```
+
+```ruby
+AppProfiler.profile_sampler_enabled = -> { sampler_enabled? }
+# OR
+Rails.application.config.app_profiler.profile_sampler_enabled = -> { sampler_enabled? }
+```
+
 
 Both backends, StackProf and Vernier, can be configured separately.
 
@@ -356,7 +363,7 @@ These can be overridden like:
 ```ruby
 AppProfiler.profile_sampler_config = AppProfiler::Sampler::Config.new(
   sample_rate: 0.5,
-  paths: ["/foo"],
+  targets: ["/foo"],
   backends_probability: { stackprof: 0.5, vernier: 0.5 },
   backend_configs: {
     stackprof: AppProfiler::Sampler::StackprofConfig.new,
@@ -367,7 +374,7 @@ AppProfiler.profile_sampler_config = AppProfiler::Sampler::Config.new(
 
 Rails.application.config.app_profiler = AppProfiler::Sampler::Config.new(
   sample_rate: 0.5,
-  paths: ["/foo"],
+  targets: ["/foo"],
   backends_probability: { stackprof: 0.5, vernier: 0.5 },
   backend_configs: {
     stackprof: AppProfiler::Sampler::StackprofConfig.new,
@@ -380,12 +387,12 @@ All the configuration parameters are optional and have default values. The defau
 
 ```ruby
 
-| Sampler Config                      | Default         |
-| --------                            | -------         |
-| sample_rate (0.0 - 1.0)             | 0.001 (0.1 %)   |
-| paths                               | ['/']           |
-| stackprof_probability               | 1.0             |
-| vernier_probability                 | 0.0             |
+| Sampler Config                                         | Default         |
+| --------                                               | -------         |
+| sample_rate (0.0 - 1.0)                                | 0.001 (0.1 %)   |
+| targets (request paths, job_names etc )                | ['/']           |
+| stackprof_probability                                  | 1.0             |
+| vernier_probability                                    | 0.0             |
 
 | StackprofConfig                     | Default |
 | --------                            | ------- |

--- a/lib/app_profiler/middleware.rb
+++ b/lib/app_profiler/middleware.rb
@@ -50,7 +50,6 @@ module AppProfiler
 
     def profile_params(params)
       return params if params.valid?
-
       return unless AppProfiler.profile_sampler_enabled
 
       AppProfiler::Sampler.profile_params(params, AppProfiler.profile_sampler_config)

--- a/lib/app_profiler/sampler.rb
+++ b/lib/app_profiler/sampler.rb
@@ -5,18 +5,21 @@ module AppProfiler
   module Sampler
     class << self
       def profile_params(request, config)
-        return unless sample?(config, request)
+        profile_params_for(request.path, config)
+      end
+
+      def profile_params_for(target, config)
+        return unless sample?(config, target)
 
         get_profile_params(config)
       end
 
       private
 
-      def sample?(config, request)
+      def sample?(config, target)
         return false if Kernel.rand > config.sample_rate
 
-        path = request.path
-        return false unless config.paths.any? { |p| path.match?(p) }
+        return false unless config.targets.any? { |t| target.match?(t) }
 
         true
       end

--- a/lib/app_profiler/sampler/config.rb
+++ b/lib/app_profiler/sampler/config.rb
@@ -5,19 +5,20 @@ require "app_profiler/sampler/vernier_config"
 module AppProfiler
   module Sampler
     class Config
-      attr_reader :sample_rate, :paths, :cpu_interval, :backends_probability
+      attr_reader :sample_rate, :targets, :cpu_interval, :backends_probability
 
       SAMPLE_RATE = 0.001 # 0.1%
-      PATHS = ["/"]
+      TARGETS = ["/"]
       BACKEND_PROBABILITES = { stackprof: 1.0, vernier: 0.0 }
       @backends = {}
 
       def initialize(sample_rate: SAMPLE_RATE,
-        paths: PATHS,
+        targets: TARGETS,
         backends_probability: BACKEND_PROBABILITES,
         backends_config: {
           stackprof: StackprofConfig.new,
-        })
+        },
+        paths: nil)
 
         if sample_rate < 0.0 || sample_rate > 1.0
           raise ArgumentError, "sample_rate must be between 0 and 1"
@@ -25,8 +26,10 @@ module AppProfiler
 
         raise ArgumentError, "mode probabilities must sum to 1" unless backends_probability.values.sum == 1.0
 
+        ActiveSupport::Deprecation.new.warn("passing paths is deprecated, use targets instead") if paths
+
         @sample_rate = sample_rate
-        @paths = paths
+        @targets = paths || targets
         @backends_config = backends_config
         @backends_probability = backends_probability
       end

--- a/test/app_profiler/app_profiler_configuration_test.rb
+++ b/test/app_profiler/app_profiler_configuration_test.rb
@@ -20,5 +20,34 @@ module AppProfiler
         AppProfiler.after_process_queue = lambda { nil }
       end
     end
+
+    test "unexpected handler profile_sampler_enabled raises ArgumentError " do
+      assert_raises(ArgumentError) do
+        AppProfiler.profile_sampler_enabled = ->(arg) { arg }
+      end
+    end
+
+    test "proc with args for profile_sampler_enabled raises ArgumentError " do
+      assert_raises(ArgumentError) do
+        AppProfiler.profile_sampler_enabled = ->(arg) { arg }
+      end
+    end
+
+    test "profile_sampler_enabled allows TrueClass, FalseClass, Proc" do
+      old_status = AppProfiler.profile_sampler_enabled
+      AppProfiler.profile_sampler_enabled = false
+      AppProfiler.profile_sampler_enabled = true
+      AppProfiler.profile_sampler_enabled = -> { false }
+    ensure
+      AppProfiler.profile_sampler_enabled = old_status
+    end
+
+    test "profile_sampler_enabled is false if Proc raises" do
+      old_status = AppProfiler.profile_sampler_enabled
+      AppProfiler.profile_sampler_enabled = -> { raise "error" }
+      assert_equal(false, AppProfiler.profile_sampler_enabled)
+    ensure
+      AppProfiler.profile_sampler_enabled = old_status
+    end
   end
 end

--- a/test/app_profiler/middleware_test.rb
+++ b/test/app_profiler/middleware_test.rb
@@ -376,7 +376,7 @@ module AppProfiler
         with_google_cloud_storage do
           AppProfiler.profile_sampler_config = AppProfiler::Sampler::Config.new(
             sample_rate: 1.0,
-            paths: ["/"],
+            targets: ["/"],
           )
 
           assert_profiles_dumped(0) do
@@ -391,6 +391,18 @@ module AppProfiler
     test "request is not sampled when sampler is not enabled" do
       with_google_cloud_storage do
         AppProfiler.profile_sampler_config = AppProfiler::Sampler::Config.new(sample_rate: 1.0)
+        assert_profiles_dumped(0) do
+          middleware = AppProfiler::Middleware.new(app_env)
+          response = middleware.call(mock_request_env(path: "/"))
+          assert_nil(response[1]["X-Profile-Async"])
+        end
+      end
+    end
+
+    test "request is not sampled when sampler is not enabled via Proc" do
+      with_google_cloud_storage do
+        AppProfiler.profile_sampler_config = AppProfiler::Sampler::Config.new(sample_rate: 1.0)
+        AppProfiler.profile_sampler_enabled = -> { false }
         assert_profiles_dumped(0) do
           middleware = AppProfiler::Middleware.new(app_env)
           response = middleware.call(mock_request_env(path: "/"))

--- a/test/app_profiler/sampler/config_test.rb
+++ b/test/app_profiler/sampler/config_test.rb
@@ -21,10 +21,15 @@ module AppProfiler
       test "default config" do
         config = Config.new
         assert_equal(Config::SAMPLE_RATE, config.sample_rate)
-        assert_equal(Config::PATHS, config.paths)
+        assert_equal(Config::TARGETS, config.targets)
         assert_equal(Config::BACKEND_PROBABILITES, config.backends_probability)
         assert_not_nil(config.get_backend_config(:stackprof))
         assert_nil(config.get_backend_config(:vernier))
+      end
+
+      test "allows passing paths" do
+        config = Config.new(paths: ["/"])
+        assert_equal(["/"], config.targets)
       end
     end
   end

--- a/test/app_profiler/sampler/sampler_test.rb
+++ b/test/app_profiler/sampler/sampler_test.rb
@@ -48,7 +48,7 @@ module AppProfiler
         Kernel.stubs(:rand).returns(0.1)
         config = Config.new(
           sample_rate: 1.0,
-          paths: ["/foo"],
+          targets: ["/foo"],
         )
 
         request = RequestParameters.new(Rack::Request.new({ "PATH_INFO" => "/foo" }))


### PR DESCRIPTION
Small improvements for the profile sampler:

- `profile_sampler_enabled` accepts a Proc now. The idea is to remove the sampler we have in Core and use this. 
- Renamed `paths` in the config to `targets`. The idea is that the sampler can be use by Jobs too -- so it makes sense to make it generic.

All changes are backwards compatible and should not break existing clients. 