### PR TITLE
add exclude target for the sampler

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,6 +391,7 @@ All the configuration parameters are optional and have default values. The defau
 | --------                                               | -------         |
 | sample_rate (0.0 - 1.0)                                | 0.001 (0.1 %)   |
 | targets (request paths, job_names etc )                | ['/']           |
+| exclude_targets (request paths, job_names etc )        | ['/ping']       |
 | stackprof_probability                                  | 1.0             |
 | vernier_probability                                    | 0.0             |
 

--- a/lib/app_profiler/sampler.rb
+++ b/lib/app_profiler/sampler.rb
@@ -3,6 +3,7 @@
 require "app_profiler/sampler/config"
 module AppProfiler
   module Sampler
+    @excluded_cache = {}
     class << self
       def profile_params(request, config)
         profile_params_for(request.path, config)
@@ -18,6 +19,12 @@ module AppProfiler
 
       def sample?(config, target)
         return false if Kernel.rand > config.sample_rate
+        return false if @excluded_cache[target]
+
+        if config.exclude_targets.any? { |t| target.match?(t) }
+          @excluded_cache[target] = true
+          return false
+        end
 
         return false unless config.targets.any? { |t| target.match?(t) }
 

--- a/lib/app_profiler/sampler/config.rb
+++ b/lib/app_profiler/sampler/config.rb
@@ -5,12 +5,12 @@ require "app_profiler/sampler/vernier_config"
 module AppProfiler
   module Sampler
     class Config
-      attr_reader :sample_rate, :targets, :cpu_interval, :backends_probability
+      attr_reader :sample_rate, :targets, :exclude_targets, :cpu_interval, :backends_probability
 
       SAMPLE_RATE = 0.001 # 0.1%
       TARGETS = ["/"]
       BACKEND_PROBABILITES = { stackprof: 1.0, vernier: 0.0 }
-      @backends = {}
+      EMPTY_ARRAY = []
 
       def initialize(sample_rate: SAMPLE_RATE,
         targets: TARGETS,
@@ -18,7 +18,8 @@ module AppProfiler
         backends_config: {
           stackprof: StackprofConfig.new,
         },
-        paths: nil)
+        paths: nil,
+        exclude_targets: EMPTY_ARRAY)
 
         if sample_rate < 0.0 || sample_rate > 1.0
           raise ArgumentError, "sample_rate must be between 0 and 1"
@@ -32,6 +33,7 @@ module AppProfiler
         @targets = paths || targets
         @backends_config = backends_config
         @backends_probability = backends_probability
+        @exclude_targets = exclude_targets
       end
 
       def get_backend_config(backend_name)

--- a/test/app_profiler/sampler/sampler_test.rb
+++ b/test/app_profiler/sampler/sampler_test.rb
@@ -58,6 +58,18 @@ module AppProfiler
         assert_nil(Sampler.profile_params(request, config))
       end
 
+      test "exclude_targets are respected" do
+        Kernel.stubs(:rand).returns(0.1)
+        config = Config.new(
+          sample_rate: 1.0,
+          targets: ["/foo"],
+          exclude_targets: ["/foo/bar"],
+        )
+
+        request = RequestParameters.new(Rack::Request.new({ "PATH_INFO" => "/foo/bar" }))
+        assert_nil(Sampler.profile_params(request, config))
+      end
+
       test "mixed backend probabilities" do
         skip("Vernier not supported") unless AppProfiler.vernier_supported?
 


### PR DESCRIPTION
Adds `exclude_targets` options, it allows apps to specify `*` for `targets` and then opt out of some using `exclude_target