### PR TITLE
expose metadata method for profiles

### DIFF
--- a/lib/app_profiler/profile.rb
+++ b/lib/app_profiler/profile.rb
@@ -81,7 +81,7 @@ module AppProfiler
     end
 
     def metadata
-      @data[:metadata]
+      raise NotImplementedError
     end
 
     def mode

--- a/lib/app_profiler/profile/stackprof.rb
+++ b/lib/app_profiler/profile/stackprof.rb
@@ -8,6 +8,10 @@ module AppProfiler
       @data[:mode]
     end
 
+    def metadata
+      @data[:metadata]
+    end
+
     def format
       FILE_EXTENSION
     end

--- a/lib/app_profiler/profile/vernier.rb
+++ b/lib/app_profiler/profile/vernier.rb
@@ -8,6 +8,10 @@ module AppProfiler
       @data[:meta][:mode]
     end
 
+    def metadata
+      @data[:meta]
+    end
+
     def format
       FILE_EXTENSION
     end

--- a/test/app_profiler/middleware_test.rb
+++ b/test/app_profiler/middleware_test.rb
@@ -334,7 +334,7 @@ module AppProfiler
           AppProfiler.middleware.any_instance.expects(:after_profile).with do |env, profile|
             return false unless request_env == env && profile.is_a?(AppProfiler::BaseProfile)
 
-            profile[:metadata][:test_key] == "test_value"
+            profile.metadata[:test_key] == "test_value"
           end.returns(true)
 
           middleware = AppProfiler::Middleware.new(app_env)

--- a/test/app_profiler/profile/stackprof_test.rb
+++ b/test/app_profiler/profile/stackprof_test.rb
@@ -31,8 +31,8 @@ module AppProfiler
     test ".from_stackprof removes id and context metadata from profile data" do
       profile = BaseProfile.from_stackprof(stackprof_profile(metadata: { id: "foo", context: "bar" }))
 
-      assert_not_operator(profile[:metadata], :key?, :id)
-      assert_not_operator(profile[:metadata], :key?, :context)
+      assert_not_operator(profile.metadata, :key?, :id)
+      assert_not_operator(profile.metadata, :key?, :context)
     end
 
     test "#id" do

--- a/test/app_profiler/profile/vernier_test.rb
+++ b/test/app_profiler/profile/vernier_test.rb
@@ -105,7 +105,7 @@ module AppProfiler
     test "#[] forwards to profile metadata" do
       profile = VernierProfile.new(vernier_profile(meta: { interval: 10_000 }))
 
-      assert_equal(10_000, profile[:meta][:interval])
+      assert_equal(10_000, profile.metadata[:interval])
     end
 
     test "#path raises an UnsafeFilename exception given chars not in allow list" do


### PR DESCRIPTION
If apps access `profile[:metadata]` directly, it blows up for Vernier, as the key is different. 

By exposing `metadata` method, apps can just use this method instead.