### PR TITLE
remove release_run_lock side-effect if already released

### DIFF
--- a/lib/app_profiler/backend/base_backend.rb
+++ b/lib/app_profiler/backend/base_backend.rb
@@ -40,7 +40,7 @@ module AppProfiler
       end
 
       def release_run_lock
-        self.class.run_lock.unlock
+        self.class.run_lock.unlock if self.class.run_lock.locked?
       rescue ThreadError
         AppProfiler.logger.warn("[AppProfiler] run lock not released as it was never acquired")
       end


### PR DESCRIPTION
I see this for every profile run`[AppProfiler] run lock not released as it was never acquired`. 

We release it twice, by calling stop twice:

https://github.com/Shopify/app_profiler/blob/9373c5adc5319b8b4df70a74c3f4f9184e28495e/lib/app_profiler/backend/stackprof_backend.rb#L32-L36

`stop -> release_run_lock -> unlock` 

>Releases the lock. Raises ThreadError if mutex wasn't locked by the current thread.

https://ruby-doc.org/core-2.5.1/Mutex.html#method-i-unlock