### PR TITLE
Validate the backend in params

### DIFF
--- a/lib/app_profiler/request_parameters.rb
+++ b/lib/app_profiler/request_parameters.rb
@@ -27,11 +27,12 @@ module AppProfiler
     end
 
     def valid?
-      if mode.blank?
+      return false if mode.blank?
+
+      unless valid_backend?
+        AppProfiler.logger.info("[AppProfiler] unsupported backend='#{backend}'")
         return false
       end
-
-      return false if backend != AppProfiler::Backend::StackprofBackend.name && !AppProfiler.vernier_supported?
 
       if AppProfiler.vernier_supported? && backend == AppProfiler::Backend::VernierBackend.name &&
           !AppProfiler::Backend::VernierBackend::AVAILABLE_MODES.include?(mode.to_sym)
@@ -48,6 +49,12 @@ module AppProfiler
       end
 
       true
+    end
+
+    def valid_backend?
+      return true if AppProfiler::Backend::StackprofBackend.name == backend
+
+      AppProfiler.vernier_supported? && AppProfiler::Backend::VernierBackend.name == backend
     end
 
     def to_h

--- a/test/app_profiler/request_parameters_test.rb
+++ b/test/app_profiler/request_parameters_test.rb
@@ -29,6 +29,13 @@ module AppProfiler
       end
     end
 
+    test "#valid? returns false when backend is not supported" do
+      AppProfiler.logger.expects(:info).with { |value| value =~ /unsupported backend='not-a-real-backend'/ }
+      params = request_params(headers: { AppProfiler.request_profile_header => "mode=cpu;backend=not-a-real-backend" })
+
+      assert_not_predicate(params, :valid?)
+    end
+
     test "#context is AppProfiler.context by default" do
       with_context("test-context") do
         AppProfiler.logger.expects(:info).never


### PR DESCRIPTION
Explicitly handle the case when the backend provided by params is not supported by AppProfiler