### PR TITLE
Add timeouts to jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,9 @@ name: CI
 on: [push]
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     strategy:
       fail-fast: false
       matrix:
@@ -33,6 +34,7 @@ jobs:
         bundle exec rake
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     strategy:
       fail-fast: false
     steps:

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -9,11 +9,12 @@ on:
 jobs:
   cla:
     runs-on: ubuntu-latest
+    timeout-minutes: 2
     if: |
-      (github.event.issue.pull_request 
+      (github.event.issue.pull_request
         && !github.event.issue.pull_request.merged_at
         && contains(github.event.comment.body, 'signed')
-      ) 
+      )
       || (github.event.pull_request && !github.event.pull_request.merged)
     steps:
       - uses: Shopify/shopify-cla-action@v1


### PR DESCRIPTION
I'm noticing our tests are timing out, and the server tests are a bit flaky (running `bundle exec rake` a few times can cause failures in the server tests). While we narrow down the test hanging, test and lint should run in under 5 minutes, and the cla check should run in under 2. I also renamed build to test, because that's what the job is doing.

eg. https://github.com/Shopify/app_profiler/actions/runs/11945979989/job/33299580603