### PR TITLE
Require time zone core_ext instead of class

### DIFF
--- a/lib/app_profiler.rb
+++ b/lib/app_profiler.rb
@@ -3,6 +3,7 @@
 require "active_support"
 require "active_support/core_ext/class"
 require "active_support/core_ext/module"
+require "active_support/core_ext/time/zones"
 require "logger"
 require "app_profiler/version"
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,7 +8,6 @@ require "rails"
 require "app_profiler"
 
 require "active_support"
-require "active_support/core_ext/time/zones"
 require "active_support/test_case"
 require "active_support/testing/autorun"
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,7 +8,7 @@ require "rails"
 require "app_profiler"
 
 require "active_support"
-require "active_support/time_with_zone"
+require "active_support/core_ext/time/zones"
 require "active_support/test_case"
 require "active_support/testing/autorun"
 


### PR DESCRIPTION
We use Time.zone, which is a core extension. If it isn't loaded, we may not be able to access the zone correctly.

https://github.com/Shopify/app_profiler/actions/runs/11962066460/job/33349616705