### PR TITLE
Start process_queue_thread when dead

### DIFF
--- a/lib/app_profiler/storage/google_cloud_storage.rb
+++ b/lib/app_profiler/storage/google_cloud_storage.rb
@@ -37,7 +37,7 @@ module AppProfiler
 
         def enqueue_upload(profile)
           mutex.synchronize do
-            process_queue_thread unless @process_queue_thread&.alive?
+            start_process_queue_thread
 
             @queue ||= init_queue
             begin
@@ -60,8 +60,10 @@ module AppProfiler
           @queue = SizedQueue.new(AppProfiler.upload_queue_max_length)
         end
 
-        def process_queue_thread
-          @process_queue_thread ||= Thread.new do
+        def start_process_queue_thread
+          return if @process_queue_thread&.alive?
+
+          @process_queue_thread = Thread.new do
             loop do
               process_queue
               sleep(AppProfiler.upload_queue_interval_secs)


### PR DESCRIPTION
Fixes the case when process A starts the background thread and process B is forked from process A. In this case, the old code would not recreate the thread because the thread variable is still there but the thread itself is dead. 

We see this a lot in pitchfork because workers are forked from `mold`, which I believe/understand is selected from a worker too.  