### PR TITLE
fix profile-viewer name

### DIFF
--- a/lib/app_profiler/viewer/firefox_viewer.rb
+++ b/lib/app_profiler/viewer/firefox_viewer.rb
@@ -48,7 +48,7 @@ module AppProfiler
 
       def setup_profile_viewer
         exec("which", "profile-viewer", silent: true) do
-          gem_install("profile_viewer")
+          gem_install("profile-viewer")
         end
         @profile_viewer_initialized = true
       end


### PR DESCRIPTION
The gem name is `profile-viewer`, `profile_viewer` errors out.