### PR TITLE
profile file name proc

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,14 @@ File names of profiles are prefixed by default with timezoned date and time, fol
 AppProfiler.profile_file_prefix = -> { "custom-prefix" }
 # OR
 Rails.application.config.app_profiler.profile_file_prefix = -> { "custom-prefix" }
+
+```
+As opposed to `profile_file_prefix`, which is used to customize the prefix of a file name, `profile_file_name` is used to provide the actual file name. If both are provided, `profile_file_name` takes precedence.
+
+```ruby
+AppProfiler.profile_file_name = ->(metadata) { "profile-#{metadata[:id]}-#{metadata[:hostname]}.json" }
+# OR
+Rails.application.config.app_profiler.profile_file_name = ->(metadata) { "profile-#{metadata[:id]}-#{metadata[:hostname]}.json" }
 ```
 
 To customize the redirect location you can provide a proc:

--- a/lib/app_profiler.rb
+++ b/lib/app_profiler.rb
@@ -68,8 +68,8 @@ module AppProfiler
   mattr_reader :profile_enqueue_failure, default: nil
   mattr_reader :after_process_queue, default: nil
   mattr_accessor :forward_metadata_on_upload, default: false
-
   mattr_accessor :profile_sampler_config
+  mattr_reader :profile_file_name
 
   class << self
     def deprecator # :nodoc:
@@ -127,6 +127,12 @@ module AppProfiler
 
     def vernier_viewer
       @@vernier_viewer ||= Viewer::FirefoxViewer # rubocop:disable Style/ClassVars
+    end
+
+    def profile_file_name=(value)
+      raise ArgumentError, "profile_file_name must be a proc" if value && !value.is_a?(Proc)
+
+      @@profile_file_name = value # rubocop:disable Style/ClassVars
     end
 
     def profile_sampler_enabled=(value)

--- a/lib/app_profiler/base_profile.rb
+++ b/lib/app_profiler/base_profile.rb
@@ -96,12 +96,16 @@ module AppProfiler
     private
 
     def path
-      filename = [
-        AppProfiler.profile_file_prefix.call,
-        mode,
-        id,
-        Socket.gethostname,
-      ].compact.join("-") << format
+      filename = if AppProfiler.profile_file_name.present?
+        AppProfiler.profile_file_name.call(metadata)
+      else
+        [
+          AppProfiler.profile_file_prefix.call,
+          mode,
+          id,
+          Socket.gethostname,
+        ].compact.join("-") << format
+      end
 
       raise UnsafeFilename if /[^0-9A-Za-z.\-\_]/.match?(filename)
 

--- a/lib/app_profiler/railtie.rb
+++ b/lib/app_profiler/railtie.rb
@@ -42,6 +42,7 @@ module AppProfiler
       AppProfiler.upload_queue_max_length = app.config.app_profiler.upload_queue_max_length || 10
       AppProfiler.upload_queue_interval_secs = app.config.app_profiler.upload_queue_interval_secs || 5
       AppProfiler.profile_file_prefix = app.config.app_profiler.profile_file_prefix || DefaultProfilePrefix
+      AppProfiler.profile_file_name = app.config.app_profiler.profile_file_name
       AppProfiler.profile_enqueue_success = app.config.app_profiler.profile_enqueue_success
       AppProfiler.profile_enqueue_failure = app.config.app_profiler.profile_enqueue_failure
       AppProfiler.after_process_queue = app.config.app_profiler.after_process_queue

--- a/test/app_profiler/profile/stackprof_profile_test.rb
+++ b/test/app_profiler/profile/stackprof_profile_test.rb
@@ -155,5 +155,14 @@ module AppProfiler
         assert_match(/^20221006-121110/, File.basename(profile.file.to_s))
       end
     end
+
+    test "#file uses custom profile_file_name block when provided" do
+      old_profile_file_name = AppProfiler.profile_file_name
+      AppProfiler.profile_file_name = ->(metadata) { "file-name-#{metadata[:id]}" }
+      profile = StackprofProfile.new(stackprof_profile(metadata: { id: "foo", context: "bar" }))
+      assert_match("file-name-foo", File.basename(profile.file.to_s))
+    ensure
+      AppProfiler.profile_file_name = old_profile_file_name
+    end
   end
 end

--- a/test/app_profiler/profile/vernier_profile_test.rb
+++ b/test/app_profiler/profile/vernier_profile_test.rb
@@ -128,5 +128,14 @@ module AppProfiler
         assert_match(/^20221006-121110/, File.basename(profile.file.to_s))
       end
     end
+
+    test "#file uses custom profile_file_name block when provided" do
+      old_profile_file_name = AppProfiler.profile_file_name
+      AppProfiler.profile_file_name = ->(metadata) { "file-name-#{metadata[:id]}" }
+      profile = VernierProfile.new(vernier_profile(meta: { id: "foo", context: "bar" }))
+      assert_match("file-name-foo", File.basename(profile.file.to_s))
+    ensure
+      AppProfiler.profile_file_name = old_profile_file_name
+    end
   end
 end


### PR DESCRIPTION
Adds a `profile_file_name` proc. This is useful if we want to make profile names predictable and link to the observability signals, like `trace_id`. README specifies its usage. 