### PR TITLE
Reintroduce VernierBackend definition check

### DIFF
--- a/lib/app_profiler.rb
+++ b/lib/app_profiler.rb
@@ -173,7 +173,7 @@ module AppProfiler
     end
 
     def vernier_supported?
-      RUBY_VERSION >= "3.2.1"
+      RUBY_VERSION >= "3.2.1" && defined?(AppProfiler::Backend::VernierBackend.name)
     end
 
     def profile_header=(profile_header)


### PR DESCRIPTION
We have to safely ensure vernier is available and we can load the constant