### PR TITLE
make sorbet / tapioca happy

### DIFF
--- a/lib/app_profiler/profile_id.rb
+++ b/lib/app_profiler/profile_id.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
-require "active_support/current_attributes"
 require "securerandom"
+require "active_support/isolated_execution_state"
+require "active_support/code_generator"
+require "active_support/current_attributes"
 
 module AppProfiler
   class ProfileId


### PR DESCRIPTION
If an app requires just `ProfileId` like `gem "app_profiler", "~> 0.2.8", require: app_profiler/profile_id"` AND is a plain ruby app, then RBI generation fails:

``` 
Running bin/tapioca gems --doc from dev.yml
Requiring all gems to prepare for compiling...
Tried to load the app from `config/application` as a Rails application but the `Rails` constant wasn't defined after loading the file.
/Users/bassam/.gem/ruby/3.4.0-preview2/gems/activesupport-7.2.1.2/lib/active_support/current_attributes.rb:169:in 'ActiveSupport::CurrentAttributes.current_instances': uninitialized constant #<Class:ActiveSupport::CurrentAttributes>::IsolatedExecutionState (NameError)
```

I do not know if there is a way better way to address this. If there is, I would very much like to explore that.
