### PR TITLE
profile-id improvements

### DIFF
--- a/lib/app_profiler.rb
+++ b/lib/app_profiler.rb
@@ -7,6 +7,9 @@ require "logger"
 require "app_profiler/version"
 
 module AppProfiler
+  PROFILE_ID_METADATA_KEY = :profile_id
+  PROFILE_BACKEND_METADATA_KEY = :profiler
+
   class ConfigurationError < StandardError
   end
 
@@ -90,6 +93,7 @@ module AppProfiler
       yield
     ensure
       self.backend = original_backend if backend
+      ProfileId::Current.reset
     end
 
     def start(*args, backend: nil, **kwargs)
@@ -160,7 +164,7 @@ module AppProfiler
 
     def backend_for(backend_name)
       if vernier_supported? &&
-          backend_name&.to_sym == AppProfiler::Backend::VernierBackend.name
+          backend_name&.to_sym == AppProfiler::VernierProfile::BACKEND_NAME
         AppProfiler::Backend::VernierBackend
       elsif backend_name&.to_sym == AppProfiler::Backend::StackprofBackend.name
         AppProfiler::Backend::StackprofBackend
@@ -174,7 +178,7 @@ module AppProfiler
     end
 
     def vernier_supported?
-      RUBY_VERSION >= "3.2.1" && defined?(AppProfiler::Backend::VernierBackend.name)
+      RUBY_VERSION >= "3.2.1" && defined?(AppProfiler::VernierProfile::BACKEND_NAME)
     end
 
     def profile_header=(profile_header)

--- a/lib/app_profiler/base_profile.rb
+++ b/lib/app_profiler/base_profile.rb
@@ -8,7 +8,7 @@ module AppProfiler
     private_constant :INTERNAL_METADATA_KEYS
     class UnsafeFilename < StandardError; end
 
-    attr_reader :id, :context
+    attr_reader :context
 
     delegate :[], to: :@data
 
@@ -34,9 +34,17 @@ module AppProfiler
     # `data` is assumed to be a Hash for Stackprof,
     # a vernier "result" object for vernier
     def initialize(data, id: nil, context: nil)
-      @id      = id.presence || ProfileId.current
+      ProfileId.current = id if id.present?
+
       @context = context
       @data    = data
+
+      metadata[PROFILE_BACKEND_METADATA_KEY] = self.class.backend_name
+      metadata[PROFILE_ID_METADATA_KEY] = ProfileId.current
+    end
+
+    def id
+      metadata[PROFILE_ID_METADATA_KEY]
     end
 
     def upload

--- a/lib/app_profiler/profile_id.rb
+++ b/lib/app_profiler/profile_id.rb
@@ -1,18 +1,38 @@
 # frozen_string_literal: true
 
-require "active_support/current_attributes"
 require "securerandom"
 
 module AppProfiler
   class ProfileId
-    class Current < ActiveSupport::CurrentAttributes
-      attribute :id
+    class Current
+      PROFILE_ID_KEY = :__app_profiler_profile_id__
+      class << self
+        # This is a thread local variable which gets reset by the middleware at the end of the request.
+        # Need to be mindful of the middleware order. If we try to access ProfileId after the middleware has finished,
+        # lets say in a middleware which runs before Profiling middleware, it will return a different value,
+        # as the middleware has already reset.
+
+        def id
+          Thread.current[PROFILE_ID_KEY] ||= SecureRandom.hex
+        end
+
+        def id=(id)
+          Thread.current[PROFILE_ID_KEY] = id
+        end
+
+        def reset
+          Thread.current[PROFILE_ID_KEY] = nil
+        end
+      end
     end
 
     class << self
       def current
-        Current.id ||= SecureRandom.hex
         Current.id
+      end
+
+      def current=(id)
+        Current.id = id
       end
     end
   end

--- a/lib/app_profiler/request_parameters.rb
+++ b/lib/app_profiler/request_parameters.rb
@@ -33,7 +33,7 @@ module AppProfiler
 
       return false if backend != AppProfiler::Backend::StackprofBackend.name && !AppProfiler.vernier_supported?
 
-      if AppProfiler.vernier_supported? && backend == AppProfiler::Backend::VernierBackend.name &&
+      if AppProfiler.vernier_supported? && backend == AppProfiler::VernierProfile::BACKEND_NAME &&
           !AppProfiler::Backend::VernierBackend::AVAILABLE_MODES.include?(mode.to_sym)
         AppProfiler.logger.info("[AppProfiler] unsupported profiling mode=#{mode} for backend #{backend}")
         return false

--- a/lib/app_profiler/stackprof_profile.rb
+++ b/lib/app_profiler/stackprof_profile.rb
@@ -4,6 +4,17 @@ module AppProfiler
   class StackprofProfile < BaseProfile
     FILE_EXTENSION = ".stackprof.json"
 
+    class << self
+      def backend_name
+        Backend::StackprofBackend.name.to_s
+      end
+    end
+
+    def initialize(data, id: nil, context: nil)
+      data[:metadata] ||= {}
+      super(data, id: id, context: context)
+    end
+
     def mode
       @data[:mode]
     end

--- a/lib/app_profiler/vernier_profile.rb
+++ b/lib/app_profiler/vernier_profile.rb
@@ -3,6 +3,19 @@
 module AppProfiler
   class VernierProfile < BaseProfile
     FILE_EXTENSION = ".vernier.json"
+    BACKEND_NAME = :vernier
+
+    class << self
+      def backend_name
+        # cannot reference Backend::VernierBackend because of different ruby versions we have to support
+        BACKEND_NAME.to_s
+      end
+    end
+
+    def initialize(data, id: nil, context: nil)
+      data[:meta] ||= {}
+      super(data, id: id, context: context)
+    end
 
     def mode
       @data[:meta][:mode]

--- a/test/app_profiler/backend_test.rb
+++ b/test/app_profiler/backend_test.rb
@@ -9,7 +9,7 @@ module AppProfiler
       assert(AppProfiler.backend = AppProfiler::Backend::StackprofBackend.name)
       AppProfiler.start
       assert(AppProfiler.running?)
-      assert_raises(BackendError) { AppProfiler.backend = AppProfiler::Backend::VernierBackend.name }
+      assert_raises(BackendError) { AppProfiler.backend = AppProfiler::VernierProfile::BACKEND_NAME }
     ensure
       AppProfiler.stop
     end
@@ -21,8 +21,8 @@ module AppProfiler
       assert(AppProfiler.backend = AppProfiler::Backend::StackprofBackend.name)
       assert_equal(AppProfiler.backend, AppProfiler::Backend::StackprofBackend.name)
       refute(AppProfiler.running?)
-      assert(AppProfiler.backend = AppProfiler::Backend::VernierBackend.name)
-      assert_equal(AppProfiler.backend, AppProfiler::Backend::VernierBackend.name)
+      assert(AppProfiler.backend = AppProfiler::VernierProfile::BACKEND_NAME)
+      assert_equal(AppProfiler.backend, AppProfiler::VernierProfile::BACKEND_NAME)
     ensure
       AppProfiler.backend = orig_backend
     end
@@ -49,7 +49,7 @@ module AppProfiler
 
       assert_equal(
         AppProfiler::Backend::VernierBackend,
-        AppProfiler.backend_for(AppProfiler::Backend::VernierBackend.name),
+        AppProfiler.backend_for(AppProfiler::VernierProfile::BACKEND_NAME),
       )
     end
 

--- a/test/app_profiler/middleware_test.rb
+++ b/test/app_profiler/middleware_test.rb
@@ -417,6 +417,16 @@ module AppProfiler
       end
     end
 
+    test "request clears profile id when finished" do
+      assert_profiles_dumped do
+        assert_profiles_uploaded do
+          middleware = AppProfiler::Middleware.new(app_env)
+          middleware.call(mock_request_env(path: "/?profile=cpu"))
+        end
+      end
+      assert_nil(Thread.current[ProfileId::Current::PROFILE_ID_KEY])
+    end
+
     private
 
     def with_profile_sampler_enabled

--- a/test/app_profiler/profile/stackprof_profile_test.rb
+++ b/test/app_profiler/profile/stackprof_profile_test.rb
@@ -108,6 +108,8 @@ module AppProfiler
 
       assert_match(/.*\.json/, profile.file.to_s)
       assert_equal(profile_data, JSON.parse(profile.file.read, symbolize_names: true))
+      assert_equal(ProfileId.current, profile.id)
+      assert_equal("stackprof", profile.metadata[PROFILE_BACKEND_METADATA_KEY])
     end
 
     test "#file creates file only once" do

--- a/test/app_profiler/profile/vernier_profile_test.rb
+++ b/test/app_profiler/profile/vernier_profile_test.rb
@@ -8,6 +8,7 @@ module AppProfiler
       profile = BaseProfile.from_vernier(vernier_profile(meta: { id: "foo", context: "bar" }))
 
       assert_equal("foo", profile.id)
+      assert_equal("foo", ProfileId.current)
       assert_equal("bar", profile.context)
     end
 
@@ -74,6 +75,8 @@ module AppProfiler
 
       assert_match(/.*\.json/, profile.file.to_s)
       assert_equal(profile_data.to_h, JSON.parse(profile.file.read, symbolize_names: true))
+      assert_equal(ProfileId.current, profile.id)
+      assert_equal("vernier", profile.metadata[PROFILE_BACKEND_METADATA_KEY])
     end
 
     test "#file creates file only once" do

--- a/test/app_profiler/profile_id_test.rb
+++ b/test/app_profiler/profile_id_test.rb
@@ -10,5 +10,26 @@ module AppProfiler
       id = ProfileId.current
       assert_same(id, ProfileId.current)
     end
+
+    test "ProfileId is different for different threads" do
+      ProfileId::Current.reset
+      id1, id2 = ""
+      Thread.new do
+        id1 = ProfileId.current
+      end
+
+      Thread.new do
+        id2 = ProfileId.current
+      end
+
+      assert_not_same(id1, id2)
+    end
+
+    test "ProfileId is different after reset" do
+      id1 = ProfileId.current
+      ProfileId::Current.reset
+      id2 = ProfileId.current
+      assert_not_same(id1, id2)
+    end
   end
 end

--- a/test/app_profiler/run_test.rb
+++ b/test/app_profiler/run_test.rb
@@ -32,8 +32,8 @@ module AppProfiler
 
       assert_equal(AppProfiler::Backend::StackprofBackend.name, AppProfiler.backend)
       refute(AppProfiler.running?)
-      AppProfiler.run(backend: AppProfiler::Backend::VernierBackend.name) do
-        assert_equal(AppProfiler::Backend::VernierBackend.name, AppProfiler.backend)
+      AppProfiler.run(backend: AppProfiler::VernierProfile::BACKEND_NAME) do
+        assert_equal(AppProfiler::VernierProfile::BACKEND_NAME, AppProfiler.backend)
       end
       assert_equal(AppProfiler.backend, AppProfiler::Backend::StackprofBackend.name)
     ensure

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -65,6 +65,10 @@ module AppProfiler
   class TestCase < ActiveSupport::TestCase
     include TestHelper
 
+    def teardown
+      ProfileId::Current.reset
+    end
+
     protected
 
     def file_fixture(fixture)


### PR DESCRIPTION
- Replaces `CurrentAttributes` with local thread storage which gets reset by the middleware at the end. The reason for this is if the profiling middleware runs before [this](https://github.com/rails/rails/blob/cf6ff17e9a3c6c1139040b519a341f55f0be16cf/actionpack/lib/action_dispatch/middleware/executor.rb#L28), then the value would be inconsistent if it is read again on the way out (sending response back). I have tried to maintain the same API interface so that it does not break existing clients
- We now persist profile_id in metadata, so that the clients do not have to do this. 
