### PR TITLE
insert profiling middleware after Rack::Events

### DIFF
--- a/lib/app_profiler/railtie.rb
+++ b/lib/app_profiler/railtie.rb
@@ -60,7 +60,11 @@ module AppProfiler
         if (Rails.env.development? || Rails.env.test?) && AppProfiler.stackprof_viewer.remote?
           app.middleware.insert_before(0, AppProfiler.viewer::Middleware)
         end
-        app.middleware.insert_before(0, AppProfiler.middleware)
+        if AppProfiler.otel_instrumentation_enabled
+          app.middleware.insert_after(Rack::Events, AppProfiler.middleware)
+        else
+          app.middleware.insert_before(0, AppProfiler.middleware)
+        end
       end
     end
 


### PR DESCRIPTION
I believe `Rack::Events` is usually one of the first middlewares in chain. For Core, it is the first. 

But for some apps it seems like it can appear after the profiling middleware. In that scenario, otel tracing attributes would not work.

Is this okay to do? @gmcgibbon 