### PR TITLE
Move time extension require

### DIFF
--- a/lib/app_profiler.rb
+++ b/lib/app_profiler.rb
@@ -3,6 +3,7 @@
 require "active_support"
 require "active_support/core_ext/class"
 require "active_support/core_ext/module"
+require "active_support/core_ext/time/zones"
 require "logger"
 require "app_profiler/version"
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,7 +8,6 @@ require "rails"
 require "app_profiler"
 
 require "active_support"
-require "active_support/time_with_zone"
 require "active_support/test_case"
 require "active_support/testing/autorun"
 


### PR DESCRIPTION
Depending on the state of the app, time zones may or may not be loaded at the time of profiling. This means we should require time zones support where we use it so that profiling will always work. This is specifically an issue for boot-time profiling.