### PR TITLE
Add duration tracking to profile objects

### DIFF
--- a/lib/app_profiler/backend/base_backend.rb
+++ b/lib/app_profiler/backend/base_backend.rb
@@ -3,8 +3,27 @@
 module AppProfiler
   module Backend
     class BaseBackend
-      def run(params = {}, &block)
-        raise NotImplementedError
+      def run(params = {})
+        started = start(params)
+        start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+        yield
+
+        return unless started
+
+        duration = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time
+
+        stop
+        results_data = results
+
+        if results_data
+          results_data.metadata[:duration] = duration
+        end
+
+        results_data
+      ensure
+        # Only stop the profiler if profiling was started in this context.
+        stop if started
       end
 
       def start(params = {})

--- a/lib/app_profiler/backend/stackprof_backend.rb
+++ b/lib/app_profiler/backend/stackprof_backend.rb
@@ -22,20 +22,6 @@ module AppProfiler
         end
       end
 
-      def run(params = {})
-        started = start(params)
-
-        yield
-
-        return unless started
-
-        stop
-        results
-      ensure
-        # Only stop the profiler if profiling was started in this context.
-        stop if started
-      end
-
       def start(params = {})
         # Do not start the profiler if StackProf was started somewhere else.
         return false if running?

--- a/lib/app_profiler/backend/vernier_backend.rb
+++ b/lib/app_profiler/backend/vernier_backend.rb
@@ -21,20 +21,6 @@ module AppProfiler
         end
       end
 
-      def run(params = {})
-        started = start(params)
-
-        yield
-
-        return unless started
-
-        stop
-        results
-      ensure
-        # Only stop the profiler if profiling was started in this context.
-        stop if started
-      end
-
       def start(params = {})
         # Do not start the profiler if we already have a collector started somewhere else.
         return false if running?

--- a/lib/app_profiler/base_profile.rb
+++ b/lib/app_profiler/base_profile.rb
@@ -47,6 +47,10 @@ module AppProfiler
       metadata[PROFILE_ID_METADATA_KEY]
     end
 
+    def duration
+      metadata[:duration]
+    end
+
     def upload
       AppProfiler.storage.upload(self).tap do |upload|
         if upload && defined?(upload.url)

--- a/test/app_profiler/run_test.rb
+++ b/test/app_profiler/run_test.rb
@@ -26,6 +26,15 @@ module AppProfiler
       assert_instance_of(StackprofProfile, profile)
     end
 
+    test ".run captures duration of the profiled block" do
+      profile = AppProfiler.run do
+        sleep(0.1)
+      end
+
+      assert_instance_of(Float, profile.duration)
+      assert_operator profile.duration, :>=, 0.1
+    end
+
     test ".run sets the backend then returns to the previous value" do
       orig_backend = AppProfiler.backend
       skip("Vernier not supported") unless AppProfiler.vernier_supported?


### PR DESCRIPTION
## Summary
- Add a  field to profile objects that tracks how long the profiled code block took to execute
- Implement in BaseBackend to avoid code duplication
- Add test to verify duration tracking

## Test plan
- Run tests: Run options: --seed 7348

# Running:

.....

Finished in 0.226686s, 22.0569 runs/s, 39.7025 assertions/s.
5 runs, 9 assertions, 0 failures, 0 errors, 0 skips
- Manually verify by using AppProfiler.run and checking that the returned profile has a duration field

🤖 Generated with [Claude Code](https://claude.ai/code)