### PR TITLE
Fix stale profile-running state after `/profile` start conflicts

### DIFF
--- a/lib/app_profiler/server.rb
+++ b/lib/app_profiler/server.rb
@@ -158,7 +158,12 @@ module AppProfiler
 
           @profile_running = true
 
-          AppProfiler.start(**stackprof_args)
+          AppProfiler.start(**stackprof_args).tap do |started|
+            @profile_running = false unless started
+          end
+        rescue
+          @profile_running = false
+          raise
         end
       end
 

--- a/test/app_profiler/profile_server_test.rb
+++ b/test/app_profiler/profile_server_test.rb
@@ -353,6 +353,19 @@ module AppProfiler
         AppProfiler.stop
       end
 
+      test "app can start profiling again after external conflict clears" do
+        begin
+          AppProfiler.start
+          get("/profile?duration=0.01")
+          assert_equal(decode_status(last_response.status), Net::HTTPConflict)
+        ensure
+          AppProfiler.stop
+        end
+
+        get("/profile?duration=0.01")
+        assert(last_response.ok?)
+      end
+
       private
 
       def with_profiled_workload(workload, &block)


### PR DESCRIPTION
### Summary
This fixes a server-side state bug where the profile app could get stuck thinking a profile was running after a failed start/conflict, causing later `/profile` requests to incorrectly return conflict.

### Root Cause
`ProfileApplication#start_running` set `@profile_running = true` before attempting `AppProfiler.start`, but did not reliably reset it when start returned `false` (conflict) or raised.

### Changes
- Updated `start_running` to reset `@profile_running` when `AppProfiler.start` does not start successfully.
- Added a rescue path to reset `@profile_running` before re-raising startup exceptions.
- Added regression coverage proving profiling works again after an external conflict clears.

### Files Changed
- `/Users/afurm/Development/app_profiler/lib/app_profiler/server.rb`
- `/Users/afurm/Development/app_profiler/test/app_profiler/profile_server_test.rb`

### Test Plan
- `bundle exec ruby -Itest test/app_profiler/profile_server_test.rb`
- `bundle exec rake test`

Both pass locally.

### Why This Matters
Without this fix, one conflict event can poison the process-local state and block all subsequent profiling attempts until restart.