### PR TITLE
Bump to 0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.1] - 2026-04-28
+
+- Support Vernier metadata (#165)
+
 ## [0.5.0] - 2026-02-18
 
 - Enable changing the query parameter used to trigger profiling (#199)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    app_profiler (0.5.0)
+    app_profiler (0.5.1)
       activesupport (>= 5.2)
       rack
       stackprof (~> 0.2)

--- a/lib/app_profiler/version.rb
+++ b/lib/app_profiler/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module AppProfiler
-  VERSION = "0.5.0"
+  VERSION = "0.5.1"
 end


### PR DESCRIPTION
## What

Bump app_profiler to 0.5.1 after #165.

## Changes

- Update `AppProfiler::VERSION` to 0.5.1
- Add changelog entry for Vernier metadata support
- Regenerate `Gemfile.lock` with `shadowenv exec -- bundle install`

## Testing

- `shadowenv exec -- bundle exec rake test`
- `shadowenv exec -- bundle exec rubocop`
- `git diff --check`