### PR TITLE
Discard block result during backend fallback

### DIFF
--- a/lib/app_profiler.rb
+++ b/lib/app_profiler.rb
@@ -100,6 +100,7 @@ module AppProfiler
         )
       end
       yield
+      nil # no profile result
     ensure
       self.backend = original_backend if backend
       ProfileId::Current.reset

--- a/test/app_profiler/run_test.rb
+++ b/test/app_profiler/run_test.rb
@@ -35,6 +35,17 @@ module AppProfiler
       assert_operator profile.duration, :>=, 0.1
     end
 
+    test ".run runs the block but does not return its result when the backend raises" do
+      ran = false
+      result = AppProfiler.run(backend: "not a real backend") do
+        ran = true
+        :block_value
+      end
+
+      assert(ran)
+      assert_nil(result)
+    end
+
     test ".run sets the backend then returns to the previous value" do
       orig_backend = AppProfiler.backend
       skip("Vernier not supported") unless AppProfiler.vernier_supported?


### PR DESCRIPTION
`AppProfiler.run` normally returns the profile result, so we should be consistent.

`nil` is already an expected result from `BaseBackend#run`, via several paths including: https://github.com/Shopify/app_profiler/blob/ef4da04cac76833ee679c680e5f1a741ace30ea8/lib/app_profiler/backend/base_backend.rb#L12