### PR TITLE
Only prevent backend switch/clear when AppProfiler is active

### DIFF
--- a/lib/app_profiler.rb
+++ b/lib/app_profiler.rb
@@ -127,7 +127,7 @@ module AppProfiler
     def backend=(new_backend)
       return if (new_profiler_backend = backend_for(new_backend)) == profiler_backend
 
-      if running?
+      if profiler_backend.locked?
         raise BackendError,
           "cannot change backend to #{new_backend} while #{backend} backend is running"
       end
@@ -269,7 +269,7 @@ module AppProfiler
     end
 
     def clear
-      profiler.stop if running?
+      profiler.stop if profiler_backend.locked?
       @profiler = nil
       @profiler_backend = nil
     end

--- a/lib/app_profiler/backend/base_backend.rb
+++ b/lib/app_profiler/backend/base_backend.rb
@@ -47,6 +47,10 @@ module AppProfiler
           @run_lock ||= Mutex.new
         end
 
+        def locked?
+          run_lock.locked?
+        end
+
         def name
           raise NotImplementedError
         end

--- a/test/app_profiler/backend_test.rb
+++ b/test/app_profiler/backend_test.rb
@@ -27,6 +27,24 @@ module AppProfiler
       AppProfiler.backend = orig_backend
     end
 
+    test ".backend= updates the backend while a foreign StackProf session is active" do
+      orig_backend = AppProfiler.backend
+      skip("Vernier not supported") unless AppProfiler.vernier_supported?
+      AppProfiler.backend = AppProfiler::Backend::StackprofBackend.name
+      AppProfiler.profiler # force @profiler memoization so AppProfiler.running? actually delegates
+
+      StackProf.start(mode: :wall, interval: 1000)
+      begin
+        AppProfiler.backend = AppProfiler::VernierProfile::BACKEND_NAME
+        assert_equal(AppProfiler::VernierProfile::BACKEND_NAME, AppProfiler.backend)
+      ensure
+        StackProf.stop
+        StackProf.results
+      end
+    ensure
+      AppProfiler.backend = orig_backend
+    end
+
     test ".backend= accepts a symbol with the backend name" do
       orig_backend = AppProfiler.backend
       skip("Vernier not supported") unless AppProfiler.vernier_supported?

--- a/test/app_profiler/run_test.rb
+++ b/test/app_profiler/run_test.rb
@@ -59,5 +59,27 @@ module AppProfiler
     ensure
       AppProfiler.backend = orig_backend
     end
+
+    test ".run swaps backend even while a foreign StackProf session is active" do
+      orig_backend = AppProfiler.backend
+      skip("Vernier not supported") unless AppProfiler.vernier_supported?
+      AppProfiler.backend = AppProfiler::Backend::StackprofBackend.name
+      AppProfiler.profiler # force @profiler memoization so AppProfiler.running? actually delegates
+
+      StackProf.start(mode: :wall, interval: 1000)
+      begin
+        profile = AppProfiler.run(backend: AppProfiler::VernierProfile::BACKEND_NAME) do
+          sleep(0.01)
+        end
+
+        assert_instance_of(AppProfiler::VernierProfile, profile)
+        assert_equal(AppProfiler::Backend::StackprofBackend.name, AppProfiler.backend)
+      ensure
+        StackProf.stop
+        StackProf.results
+      end
+    ensure
+      AppProfiler.backend = orig_backend
+    end
   end
 end


### PR DESCRIPTION
`running?` can be true if the (StackProf) backend is busy due to another caller; while that does preclude a `start`, it needn't prevent AppProfiler from otherwise changing state.